### PR TITLE
Remove leftover version import

### DIFF
--- a/src/sdg_hub/__init__.py
+++ b/src/sdg_hub/__init__.py
@@ -1,4 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 # Local
 from .sdg import SDG
-from ._version import __version__


### PR DESCRIPTION
A leftover import in the init that relied on the now-removed local version file

## Summary by Sourcery

Chores:
- Cleaned up leftover import in the package's __init__.py file that was no longer needed