### PR TITLE
fix: ignore markdown lint errors in 'examples' dir

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -17,3 +17,5 @@ ignores:
   - "venv/**"
   - ".venv/**"
   - ".tox/**"
+  - "examples/**"
+  - "!examples/**/README.md"


### PR DESCRIPTION
Linter currently registers a lot of failures here that we probably do not care about

## Summary by Sourcery

Chores:
- Add 'examples/**' to the list of ignored paths in markdown linter configuration