### PR TITLE
fix: test runner is running things that aren't tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Run unit tests with tox
         run: |
-          tox
+          tox -e py3-unit
 
       - name: Remove llama-cpp-python from cache
         if: always()


### PR DESCRIPTION
the test runner is doing every tox command, including linting, even though there is a seperate dedicated lint runner

narrow the scope of the runner to actual testing

## Summary by Sourcery

Modify the test workflow to run only unit tests instead of all tox commands

Bug Fixes:
- Prevent the test runner from executing non-test commands like linting in the CI workflow

CI:
- Update GitHub Actions workflow to specifically run only unit tests using tox -e py3-unit