### PR TITLE
github: shallow-clone for actionlint and markdown check jobs

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -36,8 +36,6 @@ jobs:
 
       - name: "Checkout"
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-        with:
-          fetch-depth: 0
 
       - name: "Download actionlint"
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,8 +38,6 @@ jobs:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
       - name: "Checkout"
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-        with:
-          fetch-depth: 0
       - name: "Check Markdown documents"
         uses: DavidAnson/markdownlint-cli2-action@b4c9feab76d8025d1e83c653fa3990936df0e6c8 # v16.0.0
         with:


### PR DESCRIPTION
For GitHub Actions that invoke `setuptools-scm`, we need the full Git history in order to get the proper versioning values from `git describe` (https://github.com/actions/checkout/issues/249).

For GitHub Actions that do not invoke `setuptools-scm`, we do not need the full Git history, so we can speed up those clone operations with shallow clones.