### PR TITLE
feat: Add model template loading from HF models

### DIFF
--- a/examples/data-generation-with-llama-70b/data-generation-with-llama-70b.ipynb
+++ b/examples/data-generation-with-llama-70b/data-generation-with-llama-70b.ipynb
@@ -102,34 +102,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Configure LLaMA 3.3 Prompt Template\n",
-    "\n",
-    "We need to register the correct chat template for our model to ensure proper prompt formatting."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Register the LLaMA 3.3 chat template\n",
-    "# This ensures proper formatting of prompts for the model\n",
-    "from transformers import AutoTokenizer\n",
-    "\n",
-    "# Load the tokenizer to get the chat template\n",
-    "tokenizer = AutoTokenizer.from_pretrained(\"meta-llama/Llama-3.3-70B-Instruct\")\n",
-    "\n",
-    "# Register the chat template in our prompt registry\n",
-    "@PromptRegistry.register(\"meta-llama/Llama-3.3-70B-Instruct\")\n",
-    "def llama_3_3_70b_chat_template():\n",
-    "    return tokenizer.chat_template"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Configure the Data Generation Pipeline\n",
     "\n",
     "Now we'll set up our Synthetic Data Generation (SDG) pipeline with the following components:\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ rich
 # do not use 8.4.0 due to a bug in the library
 # https://github.com/instructlab/instructlab/issues/1389
 tenacity>=8.3.0,!=8.4.0
+transformers
 tqdm>=4.66.2,<5.0.0

--- a/src/sdg_hub/flow.py
+++ b/src/sdg_hub/flow.py
@@ -96,9 +96,15 @@ class Flow(ABC):
                     if matched_prompt is not None:
                         block["block_config"]["model_prompt"] = matched_prompt
                     else:
-                        raise KeyError(
-                            f"Prompt not found in registry: {block['block_config']['model_id']}"
-                        )
+                        try:
+                            # test if the model_id is a valid model
+                            PromptRegistry.template_from_model(block["block_config"]["model_id"])
+                            # so we can then use the model_id as the prompt template name
+                            block["block_config"]["model_prompt"] = block["block_config"]["model_id"]
+                        except Exception as exc:
+                            raise KeyError(
+                                f"Prompt not found in registry: {block['block_config']['model_id']}"
+                            ) from exc
 
                 if self.num_samples_to_generate is not None:
                     block["num_samples"] = self.num_samples_to_generate

--- a/src/sdg_hub/registry.py
+++ b/src/sdg_hub/registry.py
@@ -1,8 +1,10 @@
 # Standard
 from typing import Union, List, Dict
+from functools import lru_cache
 
 # Third Party
 from jinja2 import Template
+from transformers import AutoTokenizer
 
 # Local
 from .logger_config import setup_logger
@@ -72,7 +74,10 @@ class PromptRegistry:
         :return: The Jinja2 template instance.
         """
         if name not in cls._registry:
-            raise KeyError(f"Template '{name}' not found.")
+            try:
+                cls._registry[name] = cls.template_from_model(name)
+            except Exception:
+                raise KeyError(f"Template '{name}' not found.")
         logger.debug(f"Retrieving prompt template '{name}'")
         return cls._registry[name]
 
@@ -120,3 +125,11 @@ class PromptRegistry:
         return template.render(
             messages=messages, add_generation_prompt=add_generation_prompt
         )
+
+    @classmethod
+    @lru_cache(maxsize=64) # setting maxsize avoid cache growing unchecked
+    def template_from_model(cls, model_name: str):
+        tokenizer = AutoTokenizer.from_pretrained(model_name)
+        logger.debug(f"Retrieved prompt template '{model_name}' from AutoTokenizer")
+        return Template(tokenizer.chat_template)
+    

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,65 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from sdg_hub.registry import PromptRegistry  # Assuming Registry is the class name
+
+class TestRegistry(unittest.TestCase):
+    def setUp(self):
+        # Clear the LRU cache before each test
+        PromptRegistry.template_from_model.cache_clear()
+
+    def test_template_from_registered_model(self):
+        """Test successful retrieval of chat template from a known model."""
+
+        # return the template as a jinja2 template
+        template = PromptRegistry.get_template("blank")
+        # get the template string
+        template_string = template.render(messages=[{"role": "user", "content": "test"}])
+        self.assertEqual(template_string, "[{'role': 'user', 'content': 'test'}]")
+
+    def test_template_from_model_successful(self):
+        """Test successful retrieval of chat template from a known model."""
+        test_model = "test_model"
+        with patch("sdg_hub.registry.AutoTokenizer") as mock_tokenizer:
+            # Setup mock
+            mock_instance = MagicMock()
+            mock_instance.chat_template = "{{ messages[0]['content'] }}"
+            mock_tokenizer.from_pretrained.return_value = mock_instance
+
+            # Test the method
+            template = PromptRegistry.template_from_model(test_model)
+            template_string = template.render(messages=[{"role": "user", "content": "test"}])
+
+            # Assertions
+            self.assertEqual(template_string, "test")
+            mock_tokenizer.from_pretrained.assert_called_once_with(test_model)
+
+    def test_template_from_model_caching(self):
+        """Test that the LRU cache is working properly."""
+        test_model = "test_model"
+        with patch("sdg_hub.registry.AutoTokenizer") as mock_tokenizer:
+            # Setup mock
+            mock_instance = MagicMock()
+            mock_instance.chat_template = "test template"
+            mock_tokenizer.from_pretrained.return_value = mock_instance
+
+            # Call the method twice
+            template1 = PromptRegistry.template_from_model(test_model)
+            template2 = PromptRegistry.template_from_model(test_model)
+
+            # Assertions
+            self.assertEqual(template1, template2)
+            # Should only be called once due to caching
+            mock_tokenizer.from_pretrained.assert_called_once_with(test_model)
+
+    def test_template_from_model_invalid_model(self):
+        """Test handling of invalid model names."""
+        invalid_model = "nonexistent-model"
+        with patch("sdg_hub.registry.AutoTokenizer") as mock_tokenizer:
+            mock_tokenizer.from_pretrained.side_effect = OSError("Model not found")
+
+            # Test that it raises an exception
+            with self.assertRaises(OSError):
+                PromptRegistry.template_from_model(invalid_model)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
o Add template_from_model method to dynamically fetch chat templates from HF models 
o Update Flow to attempt loading templates from model ID if not in registry 
o Add transformers to requirements.txt
o Add comprehensive test suite for template loading functionality 
o Remove hardcoded LLaMA 3.3 template from example notebook 
o I didn't remove the nvidia/Llama-3_3-Nemotron-Super-49B-v1 prompt in
   other examples as they didn't match the ones returned by AutoTokenizer.from_pretrained

## Summary by Sourcery

Add dynamic template loading from Hugging Face models, enabling automatic chat template retrieval for models not in the existing registry

New Features:
- Implement a method to dynamically fetch chat templates from Hugging Face models using AutoTokenizer

Enhancements:
- Modify PromptRegistry to attempt loading templates from model IDs when not found in the registry
- Add LRU caching to the template loading method to improve performance

Build:
- Add transformers library to requirements.txt

Tests:
- Add comprehensive test suite for template loading functionality, covering successful retrieval, caching, and error handling

Chores:
- Remove hardcoded LLaMA 3.3 template from example notebook