### PR TITLE
Ensure regular expressions can match end of content

### DIFF
--- a/src/sdg_hub/blocks/llmblock.py
+++ b/src/sdg_hub/blocks/llmblock.py
@@ -87,6 +87,9 @@ class LLMBlock(Block):
     def _parse(self, generated_string) -> dict:
         matches = {}
 
+        # Ensure regular expressions can match the end of the string (using a newline)
+        # we can't use "$" in end_tags because it gets escaped by re.escape as a literal "$"
+        generated_string += "\n"
         if self.parser_name is not None and self.parser_name == "custom":
             pattern = re.compile(self.parsing_pattern, re.DOTALL)
             all_matches = pattern.findall(generated_string)

--- a/tests/test_llmblock.py
+++ b/tests/test_llmblock.py
@@ -1,0 +1,68 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from src.sdg_hub.blocks.llmblock import LLMBlock
+
+
+class TestLLMBlockParsing(unittest.TestCase):
+    """Test cases for the LLMBlock parsing functionality."""
+
+    def setUp(self):
+        """Set up a mock LLMBlock for testing."""
+        # Create a mock block configuration
+        self.mock_config = {
+            "start_tags": [""],
+            "end_tags": [""],
+            "system": "Test system prompt",
+            "introduction": "Test introduction",
+            "principles": "Test principles",
+            "examples": "Test examples",
+            "generation": "Test generation",
+        }
+
+        # Create a mock client
+        self.mock_client = MagicMock()
+
+        # Mock the _load_config and server_supports_batched methods
+        with patch.object(LLMBlock, '_load_config', return_value=self.mock_config):
+            self.block = LLMBlock(
+                block_name="test_block",
+                config_path="mock_path",
+                client=self.mock_client,
+                output_cols=["output"],
+            )
+
+    def test_simple_parse(self):
+        """Test case when no start and end tags are provided"""
+        generated_string = "Test output"
+        results = self.block._parse(generated_string)
+        self.assertEqual(results["output"], ["Test output"])
+
+    def test_parse_with_newline_end_tags(self):
+        """Test parsing when the end tag is a newline."""
+        # Update the block config to use explicit newlines as end tags
+        with patch.object(self.block, 'block_config', {
+            "start_tags": ["Q.", "A."],
+            "end_tags": ["\n", "\n"],  # Explicit newline end tags
+        }):
+            self.block.output_cols = ["question", "answer"]
+
+            # Test input text
+            generated_string = """Here's a question and answer pair:
+
+            Q. A question?
+            A. An answer.
+
+            Q. Another question?
+            A. Another answer."""
+
+            # Call the parse method
+            results = self.block._parse(generated_string)
+
+            # Verify that the parsing worked correctly
+            self.assertEqual(len(results["question"]), 2, "Should have extracted 2 questions")
+            self.assertEqual(len(results["answer"]), 2, "Should have extracted 2 answers")
+            self.assertIn("A question?", results["question"][0])
+            self.assertIn("An answer.", results["answer"][0])
+            self.assertIn("Another question?", results["question"][1])
+            self.assertIn("Another answer.", results["answer"][1])


### PR DESCRIPTION
Fixes: #78

## Summary by Sourcery

Improve regular expression parsing in LLMBlock to handle end-of-content matching by appending a newline to the generated string

New Features:
- Enhanced parsing mechanism to support more flexible end-of-content matching

Bug Fixes:
- Fixed an issue with regular expression matching that prevented capturing content at the end of generated strings

Tests:
- Added comprehensive unit tests for LLMBlock parsing, including scenarios with newline-based end tags