### PR TITLE
Update the data generation notebook to not include tokenizer and LLaMA 3.3 prompt template registration code

### DIFF
--- a/examples/data-generation-with-llama-70b/data-generation-with-llama-70b.ipynb
+++ b/examples/data-generation-with-llama-70b/data-generation-with-llama-70b.ipynb
@@ -35,7 +35,7 @@
     "Before running this notebook, you'll need to:\n",
     "\n",
     "```bash \n",
-    "pip install sdg-hub==0.1.0a2\n",
+    "pip install sdg-hub==0.1.0a4\n",
     "```"
    ]
   },
@@ -102,34 +102,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Configure LLaMA 3.3 Prompt Template\n",
-    "\n",
-    "We need to register the correct chat template for our model to ensure proper prompt formatting."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Register the LLaMA 3.3 chat template\n",
-    "# This ensures proper formatting of prompts for the model\n",
-    "from transformers import AutoTokenizer\n",
-    "\n",
-    "# Load the tokenizer to get the chat template\n",
-    "tokenizer = AutoTokenizer.from_pretrained(\"meta-llama/Llama-3.3-70B-Instruct\")\n",
-    "\n",
-    "# Register the chat template in our prompt registry\n",
-    "@PromptRegistry.register(\"meta-llama/Llama-3.3-70B-Instruct\")\n",
-    "def llama_3_3_70b_chat_template():\n",
-    "    return tokenizer.chat_template"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Configure the Data Generation Pipeline\n",
     "\n",
     "Now we'll set up our Synthetic Data Generation (SDG) pipeline with the following components:\n",
@@ -140,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -346,7 +318,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },
@@ -360,7 +332,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.11.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Realized that the transformers package was missing, which led to the creation of #91. However, upon further review, it was discovered that we no longer need the AutoTokenizer as the prompt template for LLaMA 3.3 is already registered in the latest release (v0.1.0a4). This PR removes the unnecessary AutoTokenizer and prompt registration code.

## Summary by Sourcery

Remove unnecessary tokenizer and prompt template registration code for LLaMA 3.3 in the data generation notebook

Enhancements:
- Remove manual tokenizer and chat template registration as it is now handled in the latest package release

Chores:
- Update sdg-hub package version from 0.1.0a2 to 0.1.0a4