### PR TITLE
github: do not install virtualenv package

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install Packages
         run: |
-          sudo apt-get install -y cuda-toolkit git cmake build-essential virtualenv
+          sudo apt-get install -y cuda-toolkit git cmake build-essential
           nvidia-smi
           sudo ls -l /dev/nvidia*
 


### PR DESCRIPTION
This is an old, Python 2-era package. Nothing uses this package, and we do not need to install it in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Actions workflow by removing the installation of the virtualenv package during the package installation step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->