### PR TITLE
chore: Update linting configuration and enable additional fixers

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ name: Lint, Format, and MyPy
 on:
   push:
     branches:
-      - "main-disabled"
+      - "main"
     paths:
       - '**.py'
       - 'pyproject.toml'
@@ -15,7 +15,7 @@ on:
       - '.github/**'
   pull_request:
     branches:
-      - "main-disabled"
+      - "main"
     paths:
       - '**.py'
       - 'pyproject.toml'
@@ -52,6 +52,12 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install tox
+
+      - name: Show Ruff version and config
+        run: |
+          tox -e ruff -- --version
+          echo "Ruff configuration:"
+          grep -A 20 "\[tool.ruff\]" pyproject.toml
 
       - name: Run Ruff check
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,31 +102,28 @@ unfixable = []
 
 # Fixers will be enabled gradually.
 select = [
-    # "B",  # flake8-bugbear
-    # "E",  # pycodestyle
-    # "F",  # Pyflakes
-    "Q",  # flake8-quotes
-    # Ruff does not support isort's import_headings feature, yet.
-    # "I",  # isort
-    # "UP",  # pyupgrade
-    # "SIM",  # flake8-simplify
-    "TID",  # flake8-tidy-imports
+    "B",   # flake8-bugbear
+    "E",   # pycodestyle
+    "F",   # Pyflakes
+    "I",   # isort
+    "N",   # pep8-naming
+    "Q",   # flake8-quotes
+    "UP",  # pyupgrade
+    "SIM", # flake8-simplify
+    "TID", # flake8-tidy-imports
+    "D",   # pydocstyle
 ]
 ignore = [
     # some embedded strings are longer than 88 characters
     "E501",  # line too long
-    "TID252",  # Prefer absolute imports over relative imports from parent modules
+    "TID252", # Prefer absolute imports over relative imports from parent modules
 ]
 
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
 [tool.ruff.lint.isort]
-# same as .isort.cfg
 from-first = true
-# not supported yet
-# import-heading-future=Future
-# import-heading-stdlib=Standard
-# import-heading-thirdparty=Third Party
-# import-heading-firstparty=First Party
-# import-heading-localfolder=Local
 known-local-folder = ["tuning"]
 
 [tool.mypy]


### PR DESCRIPTION
# feat: enable Ruff linting with NumPy-style docstrings

## Changes
- Added Ruff linting configuration in `pyproject.toml` with the following rules:
  - Basic code quality checks (B, E, F)
  - Import sorting (I)
  - Naming conventions (N)
  - Quote consistency (Q)
  - Code modernization (UP)
  - Code simplification (SIM)
  - Import tidiness (TID)
  - Documentation style (D)
- Configured NumPy-style docstring convention for pydocstyle
- Enabled GitHub Actions workflow to run on the `main` branch

## Summary
- **Linting Configuration**
  - Added comprehensive set of Ruff rules for code quality and style enforcement
  - Set up NumPy-style docstring convention for consistent documentation
  - Configured import sorting with local folder recognition
- **CI Integration**
  - Enabled GitHub Actions workflow to run on `main` branch
  - Ensures consistent code quality across the project

## Testing
- [x] Verified Ruff configuration is valid
- [ ] Tested linting rules against existing codebase
- [ ] Confirmed GitHub Actions workflow triggers correctly

## Related
#170 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated linting workflow to provide more visibility into the Ruff linter version and configuration.
  - Broadened the set of linting rules enforced, including additional code style, bug detection, import sorting, and docstring standards.
  - Adopted the "numpy" convention for docstring style checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->