### PR TITLE
Update knowledge flows to use Llama-3.3-70B-Instruct

### DIFF
--- a/src/sdg_hub/flows/generation/knowledge/mmlu_bench.yaml
+++ b/src/sdg_hub/flows/generation/knowledge/mmlu_bench.yaml
@@ -2,7 +2,7 @@
   block_config:
     block_name: gen_mmlu_knowledge
     config_path: configs/knowledge/mcq_generation.yaml
-    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    model_id: meta-llama/Llama-3.3-70B-Instruct
     output_cols:
       - mmlubench_question
       - mmlubench_answer

--- a/src/sdg_hub/flows/generation/knowledge/simple_knowledge.yaml
+++ b/src/sdg_hub/flows/generation/knowledge/simple_knowledge.yaml
@@ -2,7 +2,7 @@
   block_config:
     block_name: gen_knowledge
     config_path: configs/knowledge/simple_generate_qa.yaml
-    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    model_id: meta-llama/Llama-3.3-70B-Instruct
     output_cols:
       - output
   gen_kwargs:

--- a/src/sdg_hub/flows/generation/knowledge/synth_knowledge.yaml
+++ b/src/sdg_hub/flows/generation/knowledge/synth_knowledge.yaml
@@ -2,7 +2,7 @@
   block_config:
     block_name: gen_knowledge
     config_path: configs/knowledge/generate_questions_responses.yaml
-    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    model_id: meta-llama/Llama-3.3-70B-Instruct
     output_cols:
       - question
       - response
@@ -20,7 +20,7 @@
   block_config:
     block_name: eval_faithfulness_qa_pair
     config_path: configs/knowledge/evaluate_faithfulness.yaml
-    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    model_id: meta-llama/Llama-3.3-70B-Instruct
     output_cols:
       - explanation
       - judgment
@@ -43,7 +43,7 @@
   block_config:
     block_name: eval_relevancy_qa_pair
     config_path: configs/knowledge/evaluate_relevancy.yaml
-    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    model_id: meta-llama/Llama-3.3-70B-Instruct
     output_cols:
       - feedback
       - score
@@ -67,7 +67,7 @@
   block_config:
     block_name: eval_verify_question
     config_path: configs/knowledge/evaluate_question.yaml
-    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    model_id: meta-llama/Llama-3.3-70B-Instruct
     output_cols:
       - explanation
       - rating

--- a/src/sdg_hub/flows/generation/knowledge/synth_knowledge1.5.yaml
+++ b/src/sdg_hub/flows/generation/knowledge/synth_knowledge1.5.yaml
@@ -8,7 +8,7 @@
   block_config:
     block_name: gen_detailed_summary
     config_path: configs/knowledge/detailed_summary.yaml
-    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    model_id: meta-llama/Llama-3.3-70B-Instruct
     output_cols:
       - summary_detailed
   gen_kwargs:
@@ -20,7 +20,7 @@
   block_config:
     block_name: gen_atomic_facts
     config_path: configs/knowledge/atomic_facts.yaml
-    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    model_id: meta-llama/Llama-3.3-70B-Instruct
     output_cols:
       - summary_atomic_facts
   gen_kwargs:
@@ -31,7 +31,7 @@
   block_config:
     block_name: gen_extractive_summary
     config_path: configs/knowledge/extractive_summary.yaml
-    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    model_id: meta-llama/Llama-3.3-70B-Instruct
     output_cols:
       - summary_extractive
   gen_kwargs:
@@ -60,7 +60,7 @@
   block_config:
     block_name: knowledge generation
     config_path: configs/knowledge/generate_questions.yaml
-    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    model_id: meta-llama/Llama-3.3-70B-Instruct
     output_cols:
       - question
     parser_kwargs:
@@ -74,7 +74,7 @@
   block_config:
     block_name: knowledge generation
     config_path: configs/knowledge/generate_responses.yaml
-    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    model_id: meta-llama/Llama-3.3-70B-Instruct
     output_cols:
       - response
   gen_kwargs:
@@ -85,7 +85,7 @@
   block_config:
     block_name: eval_faithfulness_qa_pair
     config_path: configs/knowledge/evaluate_faithfulness.yaml
-    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    model_id: meta-llama/Llama-3.3-70B-Instruct
     output_cols:
       - explanation
       - judgment
@@ -106,7 +106,7 @@
   block_config:
     block_name: eval_relevancy_qa_pair
     config_path: configs/knowledge/evaluate_relevancy.yaml
-    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    model_id: meta-llama/Llama-3.3-70B-Instruct
     output_cols:
       - feedback
       - score
@@ -128,7 +128,7 @@
   block_config:
     block_name: eval_verify_question
     config_path: configs/knowledge/evaluate_question.yaml
-    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    model_id: meta-llama/Llama-3.3-70B-Instruct
     output_cols:
       - explanation
       - rating


### PR DESCRIPTION
## Summary
- Replace mistralai/Mixtral-8x7B-Instruct-v0.1 with meta-llama/Llama-3.3-70B-Instruct across all knowledge generation flows
- Updated 4 YAML configuration files: mmlu_bench.yaml, simple_knowledge.yaml, synth_knowledge.yaml, and synth_knowledge1.5.yaml
- Improves model performance and capabilities for knowledge generation tasks

## Test plan
- [ ] Verify YAML configurations are valid
- [ ] Test knowledge generation flows with new model
- [ ] Ensure backward compatibility with existing datasets

🤖 Generated with [Claude Code](https://claude.ai/code)