### PR TITLE
Add dictionary support to BaseBlock column specifications

### DIFF
--- a/src/sdg_hub/blocks/base.py
+++ b/src/sdg_hub/blocks/base.py
@@ -7,6 +7,7 @@ with unified constructor patterns, column handling, and common functionality.
 
 # Standard
 from abc import ABC, abstractmethod
+from copy import deepcopy
 from typing import Any, Dict, List, Optional, Union
 
 # Third Party
@@ -88,17 +89,21 @@ class BaseBlock(ABC):
     @property
     def input_cols(self) -> Union[List[str], Dict[str, Any]]:
         """Get the input column specification (immutable)."""
+        if isinstance(self._input_cols, dict):
+            return deepcopy(self._input_cols)
         return self._input_cols.copy()
 
     @property
     def output_cols(self) -> Union[List[str], Dict[str, Any]]:
         """Get the output column specification (immutable)."""
+        if isinstance(self._output_cols, dict):
+            return deepcopy(self._output_cols)
         return self._output_cols.copy()
 
     def _normalize_columns(
         self, cols: Optional[Union[str, List[str], Dict[str, Any]]]
     ) -> Union[List[str], Dict[str, Any]]:
-        """Normalize column specifications to list format.
+        """Normalize column specifications to appropriate format.
 
         Parameters
         ----------
@@ -107,8 +112,10 @@ class BaseBlock(ABC):
 
         Returns
         -------
-        List[str]
-            Normalized list of column names. Empty list if cols is None.
+        Union[List[str], Dict[str, Any]]
+            Normalized column specification. Returns empty list if cols is None,
+            single-item list for strings, copy of list for lists, or deep copy
+            of dictionary for dictionaries.
 
         Raises
         ------
@@ -120,9 +127,9 @@ class BaseBlock(ABC):
         if isinstance(cols, str):
             return [cols]
         if isinstance(cols, list):
-            return cols
+            return cols.copy()
         if isinstance(cols, dict):
-            return cols
+            return deepcopy(cols)
 
         # This will only be reached if cols is not None, str, list, or dict
         raise ValueError(

--- a/src/sdg_hub/blocks/base.py
+++ b/src/sdg_hub/blocks/base.py
@@ -51,17 +51,17 @@ class BaseBlock(ABC):
     ----------
     block_name : str
         Name of the block instance.
-    input_cols : List[str]
-        Normalized list of input column names.
-    output_cols : List[str]
-        Normalized list of output column names.
+    input_cols : Union[List[str], Dict[str, Any]]
+        Normalized input column specification.
+    output_cols : Union[List[str], Dict[str, Any]]
+        Normalized output column specification.
     """
 
     def __init__(
         self,
         block_name: str,
-        input_cols: Optional[Union[str, List[str]]] = None,
-        output_cols: Optional[Union[str, List[str]]] = None,
+        input_cols: Optional[Union[str, List[str], Dict[str, Any]]] = None,
+        output_cols: Optional[Union[str, List[str], Dict[str, Any]]] = None,
         **kwargs: Any,
     ) -> None:
         """Initialize base block with standardized parameters."""
@@ -86,22 +86,24 @@ class BaseBlock(ABC):
         return self._block_name
 
     @property
-    def input_cols(self) -> List[str]:
-        """Get the input column names (immutable)."""
+    def input_cols(self) -> Union[List[str], Dict[str, Any]]:
+        """Get the input column specification (immutable)."""
         return self._input_cols.copy()
 
     @property
-    def output_cols(self) -> List[str]:
-        """Get the output column names (immutable)."""
+    def output_cols(self) -> Union[List[str], Dict[str, Any]]:
+        """Get the output column specification (immutable)."""
         return self._output_cols.copy()
 
-    def _normalize_columns(self, cols: Optional[Union[str, List[str]]]) -> List[str]:
+    def _normalize_columns(
+        self, cols: Optional[Union[str, List[str], Dict[str, Any]]]
+    ) -> Union[List[str], Dict[str, Any]]:
         """Normalize column specifications to list format.
 
         Parameters
         ----------
-        cols : Optional[Union[str, List[str]]]
-            Column specification as string, list of strings, or None.
+        cols : Optional[Union[str, List[str], Dict[str, Any]]]
+            Column specification as string, list of strings, dictionary keys, or None.
 
         Returns
         -------
@@ -111,7 +113,7 @@ class BaseBlock(ABC):
         Raises
         ------
         ValueError
-            If cols is not None, str, or List[str].
+            If cols is not None, str, List[str], or Dict.
         """
         if cols is None:
             return []
@@ -119,10 +121,12 @@ class BaseBlock(ABC):
             return [cols]
         if isinstance(cols, list):
             return cols
+        if isinstance(cols, dict):
+            return cols
 
-        # This will only be reached if cols is not None, str, or list
+        # This will only be reached if cols is not None, str, list, or dict
         raise ValueError(
-            f"Invalid column specification: {cols} (type: {type(cols)}). Must be str, List[str], or None."
+            f"Invalid column specification: {cols} (type: {type(cols)}). Must be str, List[str], Dict, or None."
         )
 
     def _validate_columns(self, dataset: Dataset) -> None:
@@ -141,8 +145,14 @@ class BaseBlock(ABC):
         if not self._input_cols:
             return
 
+        # Get column names to check based on type
+        if isinstance(self._input_cols, dict):
+            columns_to_check = list(self._input_cols.keys())
+        else:
+            columns_to_check = self._input_cols
+
         missing_columns = [
-            col for col in self._input_cols if col not in dataset.column_names
+            col for col in columns_to_check if col not in dataset.column_names
         ]
 
         if missing_columns:
@@ -196,8 +206,14 @@ class BaseBlock(ABC):
         if not self._output_cols:
             return
 
+        # Get column names to check based on type
+        if isinstance(self._output_cols, dict):
+            columns_to_check = list(self._output_cols.keys())
+        else:
+            columns_to_check = self._output_cols
+
         collision_columns = [
-            col for col in self._output_cols if col in dataset.column_names
+            col for col in columns_to_check if col in dataset.column_names
         ]
 
         if collision_columns:
@@ -235,18 +251,18 @@ class BaseBlock(ABC):
         self._validate_dataset_not_empty(dataset)
         self._validate_columns(dataset)
         self._validate_output_columns(dataset)
-    
+
     def _validate_custom(self, dataset: Dataset) -> None:
         """Hook for subclasses to add custom validation logic.
-        
+
         Override this method in subclasses to add block-specific validation
         that goes beyond the standard column and dataset validation.
-        
+
         Parameters
         ----------
         dataset : Dataset
             The dataset to validate.
-            
+
         Raises
         ------
         BlockValidationError
@@ -269,21 +285,24 @@ class BaseBlock(ABC):
         # Create input panel content
         content = Text()
         content.append("📊 Processing Input Data\n", style="bold blue")
-        content.append(f"Block Type: ", style="dim")
+        content.append("Block Type: ", style="dim")
         content.append(f"{self.__class__.__name__}\n", style="cyan")
-        content.append(f"Input Rows: ", style="dim")
+        content.append("Input Rows: ", style="dim")
         content.append(f"{row_count:,}\n", style="bold cyan")
-        content.append(f"Input Columns: ", style="dim")
+        content.append("Input Columns: ", style="dim")
         content.append(f"{len(columns)}\n", style="cyan")
-        content.append(f"Column Names: ", style="dim")
+        content.append("Column Names: ", style="dim")
         content.append(f"{', '.join(columns)}\n", style="white")
 
         if self._output_cols:
-            content.append(f"Expected Output Columns: ", style="dim")
-            content.append(f"{', '.join(self._output_cols)}", style="green")
+            content.append("Expected Output Columns: ", style="dim")
+            if isinstance(self._output_cols, dict):
+                content.append(f"{', '.join(self._output_cols.keys())}", style="green")
+            else:
+                content.append(f"{', '.join(self._output_cols)}", style="green")
         else:
-            content.append(f"Expected Output Columns: ", style="dim")
-            content.append(f"None specified", style="dim")
+            content.append("Expected Output Columns: ", style="dim")
+            content.append("None specified", style="dim")
 
         # Create and log panel
         panel = Panel(
@@ -320,7 +339,7 @@ class BaseBlock(ABC):
         content.append("✅ Processing Complete\n", style="bold green")
 
         # Row changes
-        content.append(f"Rows: ", style="dim")
+        content.append("Rows: ", style="dim")
         content.append(f"{input_rows:,}", style="cyan")
         content.append(" → ", style="dim")
         content.append(f"{output_rows:,}", style="cyan")
@@ -330,11 +349,11 @@ class BaseBlock(ABC):
         elif rows_added < 0:
             content.append(f" ({rows_added:,})", style="bold red")
         else:
-            content.append(f" (no change)", style="dim")
+            content.append(" (no change)", style="dim")
         content.append("\n")
 
         # Column changes
-        content.append(f"Columns: ", style="dim")
+        content.append("Columns: ", style="dim")
         content.append(f"{len(input_columns)}", style="cyan")
         content.append(" → ", style="dim")
         content.append(f"{len(output_columns)}", style="cyan")
@@ -343,7 +362,7 @@ class BaseBlock(ABC):
         if total_column_changes > 0:
             content.append(f" ({total_column_changes} changes)", style="yellow")
         else:
-            content.append(f" (no changes)", style="dim")
+            content.append(" (no changes)", style="dim")
         content.append("\n")
 
         # Detail column changes
@@ -425,7 +444,7 @@ class BaseBlock(ABC):
 
         # Perform comprehensive dataset validation
         self._validate_dataset(samples)
-        
+
         # Allow subclasses to add custom validation
         self._validate_custom(samples)
 

--- a/tests/blocks/test_base_block.py
+++ b/tests/blocks/test_base_block.py
@@ -131,20 +131,20 @@ class TestColumnNormalization:
         assert result == ["column"]
 
     def test_normalize_list(self):
-        """Test normalizing list returns the same list."""
+        """Test normalizing list returns a copy of the list."""
         block = DummyBlock("test_block")
         input_list = ["col1", "col2"]
         result = block._normalize_columns(input_list)
         assert result == input_list
-        assert result is input_list  # Should be the same object
+        assert result is not input_list  # Should be a copy, not the same object
 
     def test_normalize_dict(self):
-        """Test normalizing dictionary returns the same dictionary."""
+        """Test normalizing dictionary returns a deep copy of the dictionary."""
         block = DummyBlock("test_block")
         input_dict = {"col1": "prompt1", "col2": "prompt2"}
         result = block._normalize_columns(input_dict)
         assert result == input_dict
-        assert result is input_dict  # Should be the same object
+        assert result is not input_dict  # Should be a copy, not the same object
 
     def test_normalize_invalid_type(self):
         """Test normalizing invalid type raises ValueError."""
@@ -622,6 +622,98 @@ class TestCustomValidation:
 
         # Verify logging was called (input and output panels)
         assert mock_console.print.call_count == 2
+
+
+class TestDictionaryMutationProtection:
+    """Test that dictionary columns are protected from external mutations."""
+
+    def test_input_dict_mutation_protection(self):
+        """Test that external changes to input dict don't affect stored version."""
+        original_dict = {"col1": "template1", "col2": "template2"}
+        block = DummyBlock("test_block", input_cols=original_dict)
+        
+        # Verify initial state
+        assert block.input_cols == original_dict
+        
+        # Modify original dictionary
+        original_dict["col3"] = "template3"
+        original_dict["col1"] = "MODIFIED"
+        
+        # Block's internal state should be unchanged
+        assert block.input_cols == {"col1": "template1", "col2": "template2"}
+        assert "col3" not in block.input_cols
+        assert block.input_cols["col1"] == "template1"
+
+    def test_output_dict_mutation_protection(self):
+        """Test that external changes to output dict don't affect stored version."""
+        original_dict = {"output1": "result1", "output2": "result2"}
+        block = DummyBlock("test_block", output_cols=original_dict)
+        
+        # Verify initial state
+        assert block.output_cols == original_dict
+        
+        # Modify original dictionary
+        original_dict["output3"] = "result3"
+        del original_dict["output1"]
+        
+        # Block's internal state should be unchanged
+        assert block.output_cols == {"output1": "result1", "output2": "result2"}
+        assert "output3" not in block.output_cols
+
+    def test_nested_dict_mutation_protection(self):
+        """Test that nested dictionaries are also protected from mutations."""
+        nested_dict = {
+            "col1": {"template": "value1", "params": {"nested": "deep"}},
+            "col2": {"template": "value2"}
+        }
+        block = DummyBlock("test_block", input_cols=nested_dict)
+        
+        # Modify nested structure
+        nested_dict["col1"]["template"] = "MODIFIED"
+        nested_dict["col1"]["params"]["nested"] = "CHANGED"
+        nested_dict["col2"]["new_key"] = "new_value"
+        
+        # Block's internal state should be unchanged
+        assert block.input_cols["col1"]["template"] == "value1"
+        assert block.input_cols["col1"]["params"]["nested"] == "deep"
+        assert "new_key" not in block.input_cols["col2"]
+
+    def test_property_returns_independent_copies(self):
+        """Test that each call to input_cols/output_cols returns independent copies."""
+        original_dict = {"col1": "template1", "col2": "template2"}
+        block = DummyBlock("test_block", input_cols=original_dict)
+        
+        # Get two copies
+        copy1 = block.input_cols
+        copy2 = block.input_cols
+        
+        # They should be equal but not the same object
+        assert copy1 == copy2
+        assert copy1 is not copy2
+        
+        # Modifying one shouldn't affect the other
+        copy1["col3"] = "template3"
+        assert "col3" not in copy2
+        assert "col3" not in block.input_cols
+
+    def test_mixed_type_immutability(self):
+        """Test immutability works correctly for both lists and dicts."""
+        list_cols = ["col1", "col2"]
+        dict_cols = {"col3": "template3", "col4": "template4"}
+        
+        block1 = DummyBlock("test1", input_cols=list_cols, output_cols=dict_cols)
+        block2 = DummyBlock("test2", input_cols=dict_cols, output_cols=list_cols)
+        
+        # Modify originals
+        list_cols.append("col5")
+        dict_cols["col6"] = "template6"
+        
+        # Blocks should be unaffected
+        assert len(block1.input_cols) == 2
+        assert len(block2.output_cols) == 2
+        assert "col5" not in block1.input_cols
+        assert "col6" not in block1.output_cols
+        assert "col6" not in block2.input_cols
 
 
 class TestEdgeCases:

--- a/tests/blocks/test_base_block.py
+++ b/tests/blocks/test_base_block.py
@@ -73,6 +73,15 @@ class TestBaseBlockInitialization:
         assert block.input_cols == ["col1", "col2"]
         assert block.output_cols == ["out1", "out2"]
 
+    def test_initialization_with_dict_columns(self):
+        """Test initialization with dictionary column specifications."""
+        input_dict = {"col1": "prompt1", "col2": "prompt2"}
+        output_dict = {"out1": "config1", "out2": "config2"}
+        block = DummyBlock("test_block", input_cols=input_dict, output_cols=output_dict)
+
+        assert block.input_cols == input_dict
+        assert block.output_cols == output_dict
+
     def test_initialization_with_kwargs(self):
         """Test initialization with additional kwargs."""
         block = DummyBlock(
@@ -129,21 +138,29 @@ class TestColumnNormalization:
         assert result == input_list
         assert result is input_list  # Should be the same object
 
+    def test_normalize_dict(self):
+        """Test normalizing dictionary returns the same dictionary."""
+        block = DummyBlock("test_block")
+        input_dict = {"col1": "prompt1", "col2": "prompt2"}
+        result = block._normalize_columns(input_dict)
+        assert result == input_dict
+        assert result is input_dict  # Should be the same object
+
     def test_normalize_invalid_type(self):
         """Test normalizing invalid type raises ValueError."""
         block = DummyBlock("test_block")
 
         with pytest.raises(
             ValueError,
-            match="Invalid column specification.*Must be str, List\\[str\\], or None",
+            match="Invalid column specification.*Must be str, List\\[str\\], Dict, or None",
         ):
             block._normalize_columns(123)
 
         with pytest.raises(
             ValueError,
-            match="Invalid column specification.*Must be str, List\\[str\\], or None",
+            match="Invalid column specification.*Must be str, List\\[str\\], Dict, or None",
         ):
-            block._normalize_columns({"col": "value"})
+            block._normalize_columns(set(["col"]))
 
 
 class TestValidation:
@@ -166,6 +183,15 @@ class TestValidation:
         # Should not raise any exception
         block._validate_columns(dataset)
 
+    def test_validate_columns_success_with_dict(self):
+        """Test successful column validation with dictionary input."""
+        dataset = self.create_test_dataset()
+        input_dict = {"input": "prompt1", "category": "prompt2"}
+        block = DummyBlock("test_block", input_cols=input_dict)
+
+        # Should not raise any exception
+        block._validate_columns(dataset)
+
     def test_validate_columns_no_input_cols(self):
         """Test validation with no input columns required."""
         dataset = self.create_test_dataset()
@@ -178,6 +204,19 @@ class TestValidation:
         """Test validation with missing columns."""
         dataset = self.create_test_dataset()
         block = DummyBlock("test_block", input_cols=["input", "missing_col"])
+
+        with pytest.raises(MissingColumnError) as exc_info:
+            block._validate_columns(dataset)
+
+        assert exc_info.value.block_name == "test_block"
+        assert exc_info.value.missing_columns == ["missing_col"]
+        assert set(exc_info.value.available_columns) == {"input", "category"}
+
+    def test_validate_columns_missing_with_dict(self):
+        """Test validation with missing columns using dictionary input."""
+        dataset = self.create_test_dataset()
+        input_dict = {"input": "prompt1", "missing_col": "prompt2"}
+        block = DummyBlock("test_block", input_cols=input_dict)
 
         with pytest.raises(MissingColumnError) as exc_info:
             block._validate_columns(dataset)
@@ -225,6 +264,21 @@ class TestValidation:
         dataset = self.create_test_dataset()
         block = DummyBlock(
             "test_block", output_cols=["input", "new_col"]
+        )  # "input" already exists
+
+        with pytest.raises(OutputColumnCollisionError) as exc_info:
+            block._validate_output_columns(dataset)
+
+        assert exc_info.value.block_name == "test_block"
+        assert exc_info.value.collision_columns == ["input"]
+        assert set(exc_info.value.existing_columns) == {"input", "category"}
+
+    def test_validate_output_columns_collision_with_dict(self):
+        """Test output column collision detection with dictionary output."""
+        dataset = self.create_test_dataset()
+        output_dict = {"input": "config1", "new_col": "config2"}
+        block = DummyBlock(
+            "test_block", output_cols=output_dict
         )  # "input" already exists
 
         with pytest.raises(OutputColumnCollisionError) as exc_info:
@@ -427,6 +481,23 @@ class TestGetInfo:
 
         assert info == expected
 
+    def test_get_info_with_dict_columns(self):
+        """Test get_info with dictionary column specifications."""
+        input_dict = {"input": "prompt1"}
+        output_dict = {"output": "config1"}
+        block = DummyBlock("test_block", input_cols=input_dict, output_cols=output_dict)
+
+        info = block.get_info()
+
+        expected = {
+            "block_name": "test_block",
+            "block_type": "DummyBlock",
+            "input_cols": input_dict,
+            "output_cols": output_dict,
+        }
+
+        assert info == expected
+
     def test_get_info_no_columns(self):
         """Test get_info with no columns specified."""
         block = DummyBlock("test_block")
@@ -454,35 +525,35 @@ class TestCustomValidation:
     def test_custom_validation_hook_called(self):
         """Test that custom validation hook is called during __call__."""
         dataset = self.create_test_dataset()
-        
+
         # Create a block that tracks if custom validation was called
         class TestBlockWithCustomValidation(DummyBlock):
             def __init__(self, block_name: str, **kwargs):
                 super().__init__(block_name, **kwargs)
                 self.custom_validation_called = False
-                
+
             def _validate_custom(self, dataset):
                 self.custom_validation_called = True
                 super()._validate_custom(dataset)
-        
+
         block = TestBlockWithCustomValidation("test_block", input_cols=["input"])
-        
+
         # Call the block - this should trigger custom validation
         result = block(dataset)
-        
+
         # Verify custom validation was called
         assert block.custom_validation_called is True
 
     def test_custom_validation_failure(self):
         """Test that custom validation failures are properly raised."""
         dataset = self.create_test_dataset()
-        
+
         class TestBlockWithFailingValidation(DummyBlock):
             def _validate_custom(self, dataset):
                 raise BlockValidationError("Custom validation failed", "Test details")
-        
+
         block = TestBlockWithFailingValidation("test_block", input_cols=["input"])
-        
+
         # Custom validation failure should be raised
         with pytest.raises(BlockValidationError, match="Custom validation failed"):
             block(dataset)
@@ -490,31 +561,33 @@ class TestCustomValidation:
     def test_custom_validation_order(self):
         """Test that custom validation happens after standard validation."""
         empty_dataset = Dataset.from_list([])
-        
+
         class TestBlockValidationOrder(DummyBlock):
             def __init__(self, block_name: str, **kwargs):
                 super().__init__(block_name, **kwargs)
                 self.custom_validation_called = False
-                
+
             def _validate_custom(self, dataset):
                 self.custom_validation_called = True
-        
+
         block = TestBlockValidationOrder("test_block")
-        
+
         # Should fail on empty dataset validation before custom validation
         with pytest.raises(EmptyDatasetError):
             block(empty_dataset)
-        
+
         # Custom validation should not have been called due to early failure
         assert block.custom_validation_called is False
 
     def test_custom_validation_with_dataset_access(self):
         """Test that custom validation can access and inspect dataset."""
-        dataset = self.create_test_dataset([
-            {"input": "valid", "special": "good"},
-            {"input": "invalid", "special": "bad"},
-        ])
-        
+        dataset = self.create_test_dataset(
+            [
+                {"input": "valid", "special": "good"},
+                {"input": "invalid", "special": "bad"},
+            ]
+        )
+
         class TestBlockWithDatasetValidation(DummyBlock):
             def _validate_custom(self, dataset):
                 # Check that all 'special' values are 'good'
@@ -523,28 +596,30 @@ class TestCustomValidation:
                         raise BlockValidationError(
                             f"Invalid special value in row {i}: {sample['special']}"
                         )
-        
+
         block = TestBlockWithDatasetValidation("test_block", input_cols=["input"])
-        
+
         # Should fail because second row has 'bad' value
-        with pytest.raises(BlockValidationError, match="Invalid special value in row 1: bad"):
+        with pytest.raises(
+            BlockValidationError, match="Invalid special value in row 1: bad"
+        ):
             block(dataset)
 
     @patch("sdg_hub.blocks.base.console")
     def test_custom_validation_with_logging(self, mock_console):
         """Test that custom validation works with Rich logging."""
         dataset = self.create_test_dataset()
-        
+
         class TestBlockWithLoggingValidation(DummyBlock):
             def _validate_custom(self, dataset):
                 # Custom validation that passes
                 logger.info("Custom validation passed")
-        
+
         block = TestBlockWithLoggingValidation("test_block", input_cols=["input"])
-        
+
         # Should succeed and show logging panels
         result = block(dataset)
-        
+
         # Verify logging was called (input and output panels)
         assert mock_console.print.call_count == 2
 


### PR DESCRIPTION
## Summary
- Add dictionary support to BaseBlock `input_cols` and `output_cols` parameters
- Update `_normalize_columns` method to preserve dictionary inputs instead of converting to list
- Enhance validation methods to handle dictionary inputs by extracting keys for validation
- Update logging to display dictionary column names correctly in Rich panels
- Add comprehensive test coverage for all dictionary functionality

## Changes Made
### BaseBlock (`src/sdg_hub/blocks/base.py`)
- **Type hints**: Added `Dict[str, Any]` support to constructor and property signatures
- **`_normalize_columns` method**: Now preserves dictionary input structure
- **Validation methods**: Updated `_validate_columns` and `_validate_output_columns` to handle dict inputs
- **Logging**: Enhanced `_log_input_data` to display dict column names in output panels
- **Properties**: Updated return types to `Union[List[str], Dict[str, Any]]`

### Tests (`tests/blocks/test_base_block.py`)
- Added initialization tests for dictionary column specifications
- Added normalization tests for dictionary preservation
- Added validation tests for dictionary input validation and error cases
- Added get_info tests for dictionary column handling
- Updated error message validation for new supported types

## Benefits
- **Prompt Builder Integration**: Enables prompt builders to pass input columns as dictionaries
- **Structure Preservation**: Dictionary structure is maintained throughout block lifecycle
- **Backward Compatibility**: Full compatibility with existing string/list column specifications
- **Type Safety**: Proper type hints and validation for all supported input types

## Test Coverage
All 46 existing tests pass plus 6 new tests specifically for dictionary functionality:
- `test_initialization_with_dict_columns`
- `test_normalize_dict` 
- `test_validate_columns_success_with_dict`
- `test_validate_columns_missing_with_dict`
- `test_validate_output_columns_collision_with_dict`
- `test_get_info_with_dict_columns`

## Example Usage
```python
# Now supported: dictionary input columns
input_dict = {"user_query": "prompt_template", "context": "context_template"}
block = SomeBlock("my_block", input_cols=input_dict, output_cols=["response"])

# Dictionary structure is preserved
assert isinstance(block.input_cols, dict)
assert block.input_cols["user_query"] == "prompt_template"
```

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded support for specifying input and output columns using dictionaries, in addition to strings and lists.  
* **Bug Fixes**
  * Improved validation and logging to correctly handle dictionary-based column specifications.  
* **Tests**
  * Added comprehensive tests to ensure correct handling and immutability of dictionary column specifications across initialization, normalization, validation, collision detection, and info reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->