### PR TITLE
Remove obsolete MANIFEST.in file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-exclude sdg_hub/configs/data_recipes/knowledge/default_recipt.yaml
-exclude sdg_hub/configs/data_recipes/skills/default_recipt.yaml


### PR DESCRIPTION
## Summary
- Remove obsolete MANIFEST.in file that was excluding non-existent YAML files

## Details
The MANIFEST.in file was excluding two YAML files with typos in their names (`default_recipt.yaml` instead of `default_recipe.yaml`) that no longer exist in the repository. Since these files don't exist anymore, this manifest file serves no purpose and can be safely removed.

## Test plan
- [x] Verify the excluded files don't exist in the repository
- [x] Confirm no other references to MANIFEST.in in the codebase
- [x] Package build should work without this file

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package distribution to include additional YAML configuration files that were previously excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->