### PR TITLE
Add a Japanese knowledge SDG tutorial

### DIFF
--- a/examples/knowledge_tuning/data-generation-japanese/.gitignore
+++ b/examples/knowledge_tuning/data-generation-japanese/.gitignore
@@ -1,0 +1,7 @@
+/model_comparison*.md*
+/model_output*.md*
+/seed_data*.jsonl*
+/generated_data*.jsonl*
+/messages_data*.jsonl*
+Tmp*/
+tmp*/

--- a/examples/knowledge_tuning/data-generation-japanese/.gitignore
+++ b/examples/knowledge_tuning/data-generation-japanese/.gitignore
@@ -1,5 +1,4 @@
 /model_comparison*.md*
-/model_output*.md*
 /seed_data*.jsonl*
 /generated_data*.jsonl*
 /messages_data*.jsonl*

--- a/examples/knowledge_tuning/data-generation-japanese/data-generation-japanese.ipynb
+++ b/examples/knowledge_tuning/data-generation-japanese/data-generation-japanese.ipynb
@@ -1,0 +1,986 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Japanese Synthetic Data Generation Tutorial using phi4\n",
+    "\n",
+    "This tutorial demonstrates how to use SDG repository to generate synthetic question-answer pairs from Japanese documents using large language models like phi4. We will also generate data using llama3 and mixtral models for comparison. We'll cover:\n",
+    "\n",
+    "1. Setting up the environment\n",
+    "2. Connecting to LLM servers\n",
+    "3. Configuring the data generation pipeline\n",
+    "4. Generating data with different models\n",
+    "5. Comparing results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Enable auto-reloading of modules - useful during development\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup Instructions\n",
+    "\n",
+    "Before running this notebook, you'll need to:\n",
+    "\n",
+    "```bash\n",
+    "pip install sdg-hub[examples]\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import required libraries\n",
+    "# datasets: For handling our data\n",
+    "# OpenAI: For interfacing with the LLM servers\n",
+    "# SDG components: For building our data generation pipeline\n",
+    "from datasets import load_dataset, Dataset\n",
+    "from openai import OpenAI\n",
+    "\n",
+    "from sdg_hub.flow import Flow\n",
+    "from sdg_hub.sdg import SDG\n",
+    "from sdg_hub.registry import PromptRegistry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "now = datetime.now()\n",
+    "timestamp = now.strftime('%Y%m%d-%H%M%S')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "force_ascii = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Configure Flow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flow_config = \"synth_knowledge1.5\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Configure Parallelism"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# See src/sdg_hub/flow_runner.py\n",
+    "num_workers = 32   # Number of worker processes to use, by default 32.\n",
+    "batch_size = 8     # Batch size for processing, by default 8.\n",
+    "save_freq = 2      # Frequency (in batches) at which to save checkpoints, by default 2.\n",
+    "\n",
+    "# For testing\n",
+    "# num_workers = 1    # Number of worker processes to use, by default 32.\n",
+    "# batch_size = 1     # Batch size for processing, by default 8.\n",
+    "# save_freq = 1000   # Frequency (in batches) at which to save checkpoints, by default 2."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Configure Models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Served model name\n",
+    "phi4_model_name = \"microsoft/phi-4\"\n",
+    "llama3_model_name = \"meta-llama/Llama-3.3-70B-Instruct\"\n",
+    "mixtral_model_name = \"mistralai/Mixtral-8x7B-Instruct-v0.1\"\n",
+    "\n",
+    "phi4_short_name = \"phi4\"\n",
+    "llama3_short_name = \"llama3\"\n",
+    "mixtral_short_name = \"mixtral\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "use_phi4 = True\n",
+    "use_llama3 = False\n",
+    "use_mixtral = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_base_url(model_name: str) -> str:\n",
+    "    endpoint = \"http://0.0.0.0:8000\"\n",
+    "    return f\"{endpoint}/v1\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Configure Seed Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Configure `data_name` such that the seed data file is `seed_data_${data_name}.jsonl`.\n",
+    "\n",
+    "Set `\"ja\"` to `data_lang` if the seed data are in Japanese. Otherwise, set `\"\"`.\n",
+    "\n",
+    "Set how many times (e.g., `5`) for each seed data to be used for generation to `repeat_times`. It could generate more data at the cost of generation time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_name = \"\"\n",
+    "data_lang = \"ja\"\n",
+    "repeat_times = 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_data_name = f\"_{data_name}\" if data_name is not None and len(data_name) > 0 else \"\"\n",
+    "_data_lang = f\"_{data_lang}\" if data_lang is not None and len(data_lang) > 0 else \"\"\n",
+    "\n",
+    "seed_data_path = f\"seed_data{_data_name}.jsonl\"\n",
+    "\n",
+    "_data_name_repeat = f\"{_data_name}_r{repeat_times}\" if repeat_times > 1 else _data_name"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load and Prepare Seed Data\n",
+    "\n",
+    "We'll load our seed data (documents) that will be used to generate question-answer pairs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the seed data from JSON file\n",
+    "ds = load_dataset('json', data_files=seed_data_path, split='train')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "(Optional) Sample Seed Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For testing, we'll use just one example\n",
+    "# ds = ds.select(range(1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Repeat Seed Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if repeat_times > 1:\n",
+    "    ds = ds.repeat(repeat_times)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add Seed ID"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add seed_id column to preserve repetition in seed data\n",
+    "# See https://github.com/Red-Hat-AI-Innovation-Team/sdg_hub/blob/42650f1340a2d3576818d68e05508dfe2a8d04bd/src/sdg_hub/checkpointer.py#L103\n",
+    "ds = ds.add_column(\"seed_id\", list(range(len(ds))))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Loaded {len(ds)} seed data\", flush=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Utilities for Generated Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def to_messages(generated_data: Dataset) -> Dataset:\n",
+    "    seen = set()\n",
+    "    messages_list: list[dict[str, any]] = []\n",
+    "    for generated_data_i in generated_data:\n",
+    "        user = generated_data_i['question']\n",
+    "        assistant = generated_data_i['response']\n",
+    "        messages = [\n",
+    "            {\"role\": \"user\", \"content\": user},\n",
+    "            {\"role\": \"assistant\", \"content\": assistant},\n",
+    "        ]\n",
+    "        # deduplicate messages\n",
+    "        key = tuple([frozenset(d.items()) for d in messages])\n",
+    "        if key not in seen:\n",
+    "            seen.add(key)\n",
+    "            messages_list.append({\"messages\": messages})\n",
+    "    messages_data = Dataset.from_list(messages_list)\n",
+    "    return messages_data\n",
+    "\n",
+    "def document_type(generated_data_i: dict[str, any]) -> str:\n",
+    "    dataset_type = generated_data_i.get('dataset_type', None)\n",
+    "    if dataset_type is not None:\n",
+    "        _document_type = f\" ({dataset_type})\"\n",
+    "    else:\n",
+    "        _document_type = \"\"\n",
+    "    return _document_type\n",
+    "\n",
+    "def print_seed_data(f, generated_data_i) -> None:\n",
+    "    icl_document = generated_data_i.get('icl_document', None)\n",
+    "    if icl_document is not None:\n",
+    "        f.write(f\"### ICL example\\n\\n\")\n",
+    "        f.write(f\"#### icl_document\\n\")\n",
+    "        f.write(icl_document + \"\\n\\n\")\n",
+    "    icl_query_1 = generated_data_i.get('icl_query_1', None)\n",
+    "    if icl_query_1 is not None:\n",
+    "        f.write(f\"#### icl_query_1\\n\")\n",
+    "        f.write(icl_query_1 + \"\\n\\n\")\n",
+    "    icl_response_1 = generated_data_i.get('icl_response_1', None)\n",
+    "    if icl_response_1 is not None:\n",
+    "        f.write(f\"#### icl_response_1\\n\")\n",
+    "        f.write(icl_response_1 + \"\\n\\n\")\n",
+    "    icl_query_2 = generated_data_i.get('icl_query_2', None)\n",
+    "    if icl_query_2 is not None:\n",
+    "        f.write(f\"#### icl_query_2\\n\")\n",
+    "        f.write(icl_query_2 + \"\\n\\n\")\n",
+    "    icl_response_2 = generated_data_i.get('icl_response_2', None)\n",
+    "    if icl_response_2 is not None:\n",
+    "        f.write(f\"#### icl_response_2\\n\")\n",
+    "        f.write(icl_response_2 + \"\\n\\n\")\n",
+    "    icl_query_3 = generated_data_i.get('icl_query_3', None)\n",
+    "    if icl_query_3 is not None:\n",
+    "        f.write(f\"#### icl_query_3\\n\")\n",
+    "        f.write(icl_query_3 + \"\\n\\n\")\n",
+    "    icl_response_3 = generated_data_i.get('icl_response_3', None)\n",
+    "    if icl_response_3 is not None:\n",
+    "        f.write(f\"#### icl_response_3\\n\")\n",
+    "        f.write(icl_response_3 + \"\\n\\n\")\n",
+    "    document_outline = generated_data_i.get('document_outline', None)\n",
+    "    if document_outline is not None:\n",
+    "        f.write(f\"### document_outline\\n\")\n",
+    "        f.write(document_outline + \"\\n\\n\")\n",
+    "    raw_document = generated_data_i.get('raw_document', None)\n",
+    "    if raw_document is not None:\n",
+    "        f.write(f\"### raw_document (not used for Q&A generation)\\n\")\n",
+    "        f.write(raw_document + \"\\n\\n\")\n",
+    "\n",
+    "def print_generated_data(f, generated_data_i, short_name: str) -> None:\n",
+    "    print_seed_data(f, generated_data_i)\n",
+    "    f.write(f\"### document{document_type(generated_data_i)} from {short_name}\\n\")\n",
+    "    f.write(generated_data_i['document'] + \"\\n\\n\")\n",
+    "    f.write(f\"### question from {short_name}\\n\")\n",
+    "    f.write(generated_data_i['question'] + \"\\n\\n\")\n",
+    "    f.write(f\"### response from {short_name}\\n\")\n",
+    "    f.write(generated_data_i['response'] + \"\\n\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## SDG with phi4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setting up phi4 Model\n",
+    "\n",
+    "Start the vLLM server (run in terminal):\n",
+    "```bash\n",
+    "vllm serve ${phi4_model_name}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if use_phi4:\n",
+    "    # Configure OpenAI client\n",
+    "    phi4_base_url = get_base_url(phi4_model_name)\n",
+    "\n",
+    "    phi4_client = OpenAI(\n",
+    "        api_key=\"EMPTY\",\n",
+    "        base_url=phi4_base_url,\n",
+    "    )\n",
+    "\n",
+    "    print(f\"Connected to model: {phi4_model_name}\", flush=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Configure phi4 Prompt Template\n",
+    "\n",
+    "We need to register the correct chat template for our model to ensure proper prompt formatting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if use_phi4 and phi4_model_name not in PromptRegistry.get_registry():\n",
+    "    # Copy the chat template\n",
+    "    from sdg_hub.prompts import microsoft_phi_chat_template\n",
+    "    _phi4_chat_template = microsoft_phi_chat_template()\n",
+    "\n",
+    "    # Register the chat template\n",
+    "    @PromptRegistry.register(phi4_model_name)\n",
+    "    def phi4_chat_template():\n",
+    "        return _phi4_chat_template"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Configure phi4 Pipeline\n",
+    "\n",
+    "Now we'll set up our Synthetic Data Generation (SDG) pipeline with the following components:\n",
+    "1. SDG Flow configuration from YAML\n",
+    "2. SDG Pipeline setup\n",
+    "3. SDG configuration with batch processing, number of workers, and save frequency parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if use_phi4:\n",
+    "    # Load the flow configuration from YAML file\n",
+    "    flow_phi4 = Flow(phi4_client).get_flow_from_file(f\"{flow_config}{_data_lang}_{phi4_short_name}.yaml\")\n",
+    "\n",
+    "    # Initialize the SDG pipeline with processing parameters\n",
+    "    sdg_phi4 = SDG(\n",
+    "        [flow_phi4],\n",
+    "        num_workers=num_workers,\n",
+    "        batch_size=batch_size,\n",
+    "        save_freq=save_freq,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Generate Data with phi4\n",
+    "\n",
+    "Now we'll use our configured pipeline to generate synthetic question-answer pairs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if use_phi4:\n",
+    "    # Generate data and save checkpoints\n",
+    "    generated_data_phi4 = sdg_phi4.generate(ds, checkpoint_dir=f\"Tmp{_data_name_repeat}_{phi4_short_name}\")\n",
+    "\n",
+    "    generated_data_path_phi4 = f\"generated_data{_data_name_repeat}_{timestamp}_{phi4_short_name}.jsonl\"\n",
+    "    generated_data_phi4.to_json(generated_data_path_phi4, orient=\"records\", lines=True, force_ascii=force_ascii)\n",
+    "    print(f\"Data saved to {generated_data_path_phi4}\", flush=True)\n",
+    "\n",
+    "    # Save generated data in messages format for training\n",
+    "    messages_data_phi4 = to_messages(generated_data_phi4)\n",
+    "\n",
+    "    messages_data_path_phi4 = f\"messages_data{_data_name_repeat}_{timestamp}_{phi4_short_name}.jsonl\"\n",
+    "    messages_data_phi4.to_json(messages_data_path_phi4, orient=\"records\", lines=True, force_ascii=force_ascii)\n",
+    "    print(f\"Messages data saved to {messages_data_path_phi4}\", flush=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Review Generated Data with phi4\n",
+    "\n",
+    "Save the outputs from the model to a markdown file for easy review."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if use_phi4:\n",
+    "    # Save comparison results to markdown file\n",
+    "    model_comparison_path = f\"model_comparison{_data_name_repeat}_{timestamp}_{phi4_short_name}.md\"\n",
+    "\n",
+    "    if 'generated_data_phi4' in locals():\n",
+    "        num_generated_data_phi4 = len(generated_data_phi4)\n",
+    "    else:\n",
+    "        num_generated_data_phi4 = 0\n",
+    "\n",
+    "    with open(model_comparison_path, \"w\") as f:\n",
+    "        # Number of examples to compare\n",
+    "        k = num_generated_data_phi4\n",
+    "\n",
+    "        # Compare generated Q&A pairs\n",
+    "        for i in range(k):\n",
+    "            f.write(f\"# Example #{i+1}\\n\\n\")\n",
+    "\n",
+    "            if i < num_generated_data_phi4:\n",
+    "                # phi4 results\n",
+    "                generated_data_i = generated_data_phi4[i]\n",
+    "                short_name = phi4_short_name\n",
+    "                print_generated_data(f, generated_data_i, short_name)\n",
+    "\n",
+    "            f.write(\"\\n\")\n",
+    "\n",
+    "    print(f\"Wrote {k} examples to {model_comparison_path}\", flush=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## (Optional) SDG with llama3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setting up llama3 Model\n",
+    "\n",
+    "Start the vLLM server (run in terminal):\n",
+    "```bash\n",
+    "vllm serve ${llama3_model_name} --tensor-parallel-size 8\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if use_llama3:\n",
+    "    # Configure OpenAI client\n",
+    "    llama3_base_url = get_base_url(llama3_model_name)\n",
+    "\n",
+    "    llama3_client = OpenAI(\n",
+    "        api_key=\"EMPTY\",\n",
+    "        base_url=llama3_base_url,\n",
+    "    )\n",
+    "\n",
+    "    print(f\"Connected to model: {llama3_model_name}\", flush=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Configure llama3 Prompt Template\n",
+    "\n",
+    "We need to register the correct chat template for our model to ensure proper prompt formatting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if use_llama3 and llama3_model_name not in PromptRegistry.get_registry():\n",
+    "    # Copy the chat template\n",
+    "    from sdg_hub.prompts import meta_llama_chat_template\n",
+    "    _llama3_chat_template = meta_llama_chat_template()\n",
+    "\n",
+    "    # Register the chat template\n",
+    "    @PromptRegistry.register(llama3_model_name)\n",
+    "    def llama3_chat_template():\n",
+    "        return _llama3_chat_template"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Configure llama3 Pipeline\n",
+    "\n",
+    "Now we'll set up our Synthetic Data Generation (SDG) pipeline with the following components:\n",
+    "1. SDG Flow configuration from YAML\n",
+    "2. SDG Pipeline setup\n",
+    "3. SDG configuration with batch processing, number of workers, and save frequency parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if use_llama3:\n",
+    "    # Load the flow configuration from YAML file\n",
+    "    flow_llama3 = Flow(llama3_client).get_flow_from_file(f\"{flow_config}{_data_lang}_{llama3_short_name}.yaml\")\n",
+    "\n",
+    "    # Initialize the SDG pipeline with processing parameters\n",
+    "    sdg_llama3 = SDG(\n",
+    "        [flow_llama3],\n",
+    "        num_workers=num_workers,\n",
+    "        batch_size=batch_size,\n",
+    "        save_freq=save_freq,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Generate Data with llama3\n",
+    "\n",
+    "Now we'll use our configured pipeline to generate synthetic question-answer pairs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if use_llama3:\n",
+    "    # Generate data and save checkpoints\n",
+    "    generated_data_llama3 = sdg_llama3.generate(ds, checkpoint_dir=f\"Tmp{_data_name_repeat}_{llama3_short_name}\")\n",
+    "\n",
+    "    generated_data_path_llama3 = f\"generated_data{_data_name_repeat}_{timestamp}_{llama3_short_name}.jsonl\"\n",
+    "    generated_data_llama3.to_json(generated_data_path_llama3, orient=\"records\", lines=True, force_ascii=force_ascii)\n",
+    "    print(f\"Data saved to {generated_data_path_llama3}\", flush=True)\n",
+    "\n",
+    "    # Save generated data in messages format for training\n",
+    "    messages_data_llama3 = to_messages(generated_data_llama3)\n",
+    "\n",
+    "    messages_data_path_llama3 = f\"messages_data{_data_name_repeat}_{timestamp}_{llama3_short_name}.jsonl\"\n",
+    "    messages_data_llama3.to_json(messages_data_path_llama3, orient=\"records\", lines=True, force_ascii=force_ascii)\n",
+    "    print(f\"Messages data saved to {messages_data_path_llama3}\", flush=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Review Generated Data with llama3\n",
+    "\n",
+    "Save the outputs from the model to a markdown file for easy review."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if use_llama3:\n",
+    "    # Save comparison results to markdown file\n",
+    "    model_comparison_path = f\"model_comparison{_data_name_repeat}_{timestamp}_{llama3_short_name}.md\"\n",
+    "\n",
+    "    if 'generated_data_llama3' in locals():\n",
+    "        num_generated_data_llama3 = len(generated_data_llama3)\n",
+    "    else:\n",
+    "        num_generated_data_llama3 = 0\n",
+    "\n",
+    "    with open(model_comparison_path, \"w\") as f:\n",
+    "        # Number of examples to compare\n",
+    "        k = num_generated_data_llama3\n",
+    "\n",
+    "        # Compare generated Q&A pairs\n",
+    "        for i in range(k):\n",
+    "            f.write(f\"# Example #{i+1}\\n\\n\")\n",
+    "\n",
+    "            if i < num_generated_data_llama3:\n",
+    "                # llama3 results\n",
+    "                generated_data_i = generated_data_llama3[i]\n",
+    "                short_name = llama3_short_name\n",
+    "                print_generated_data(f, generated_data_i, short_name)\n",
+    "\n",
+    "            f.write(\"\\n\")\n",
+    "\n",
+    "    print(f\"Wrote {k} examples to {model_comparison_path}\", flush=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## (Optional) SDG with mixtral"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setting up mixtral Model\n",
+    "\n",
+    "Start the vLLM server (run in terminal):\n",
+    "```bash\n",
+    "vllm serve ${mixtral_model_name} --tensor-parallel-size 8\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if use_mixtral:\n",
+    "    # Configure OpenAI client\n",
+    "    mixtral_base_url = get_base_url(mixtral_model_name)\n",
+    "\n",
+    "    mixtral_client = OpenAI(\n",
+    "        api_key=\"EMPTY\",\n",
+    "        base_url=mixtral_base_url,\n",
+    "    )\n",
+    "\n",
+    "    print(f\"Connected to model: {mixtral_model_name}\", flush=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Configure mixtral Prompt Template\n",
+    "\n",
+    "We need to register the correct chat template for our model to ensure proper prompt formatting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if use_mixtral and mixtral_model_name not in PromptRegistry.get_registry():\n",
+    "    # Copy the chat template\n",
+    "    from sdg_hub.prompts import mistral_chat_template\n",
+    "    _mixtral_chat_template = mistral_chat_template()\n",
+    "\n",
+    "    # Register the chat template\n",
+    "    @PromptRegistry.register(mixtral_model_name)\n",
+    "    def mixtral_chat_template():\n",
+    "        return _mixtral_chat_template"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Configure mixtral Pipeline\n",
+    "\n",
+    "Now we'll set up our Synthetic Data Generation (SDG) pipeline with the following components:\n",
+    "1. SDG Flow configuration from YAML\n",
+    "2. SDG Pipeline setup\n",
+    "3. SDG configuration with batch processing, number of workers, and save frequency parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if use_mixtral:\n",
+    "    # Load the flow configuration from YAML file\n",
+    "    flow_mixtral = Flow(mixtral_client).get_flow_from_file(f\"{flow_config}{_data_lang}_{mixtral_short_name}.yaml\")\n",
+    "\n",
+    "    # Initialize the SDG pipeline with processing parameters\n",
+    "    sdg_mixtral = SDG(\n",
+    "        [flow_mixtral],\n",
+    "        num_workers=num_workers,\n",
+    "        batch_size=batch_size,\n",
+    "        save_freq=save_freq,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Generate Data with mixtral\n",
+    "\n",
+    "Now we'll use our configured pipeline to generate synthetic question-answer pairs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if use_mixtral:\n",
+    "    # Generate data and save checkpoints\n",
+    "    generated_data_mixtral = sdg_mixtral.generate(ds, checkpoint_dir=f\"Tmp{_data_name_repeat}_{mixtral_short_name}\")\n",
+    "\n",
+    "    generated_data_path_mixtral = f\"generated_data{_data_name_repeat}_{timestamp}_{mixtral_short_name}.jsonl\"\n",
+    "    generated_data_mixtral.to_json(generated_data_path_mixtral, orient=\"records\", lines=True, force_ascii=force_ascii)\n",
+    "    print(f\"Data saved to {generated_data_path_mixtral}\", flush=True)\n",
+    "\n",
+    "    # Save generated data in messages format for training\n",
+    "    messages_data_mixtral = to_messages(generated_data_mixtral)\n",
+    "\n",
+    "    messages_data_path_mixtral = f\"messages_data{_data_name_repeat}_{timestamp}_{mixtral_short_name}.jsonl\"\n",
+    "    messages_data_mixtral.to_json(messages_data_path_mixtral, orient=\"records\", lines=True, force_ascii=force_ascii)\n",
+    "    print(f\"Messages data saved to {messages_data_path_mixtral}\", flush=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Review Generated Data with mixtral\n",
+    "\n",
+    "Save the outputs from the model to a markdown file for easy review."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if use_mixtral:\n",
+    "    # Save comparison results to markdown file\n",
+    "    model_comparison_path = f\"model_comparison{_data_name_repeat}_{timestamp}_{mixtral_short_name}.md\"\n",
+    "\n",
+    "    if 'generated_data_mixtral' in locals():\n",
+    "        num_generated_data_mixtral = len(generated_data_mixtral)\n",
+    "    else:\n",
+    "        num_generated_data_mixtral = 0\n",
+    "\n",
+    "    with open(model_comparison_path, \"w\") as f:\n",
+    "        # Number of examples to compare\n",
+    "        k = num_generated_data_mixtral\n",
+    "\n",
+    "        # Compare generated Q&A pairs\n",
+    "        for i in range(k):\n",
+    "            f.write(f\"# Example #{i+1}\\n\\n\")\n",
+    "\n",
+    "            if i < num_generated_data_mixtral:\n",
+    "                # mixtral results\n",
+    "                generated_data_i = generated_data_mixtral[i]\n",
+    "                short_name = mixtral_short_name\n",
+    "                print_generated_data(f, generated_data_i, short_name)\n",
+    "\n",
+    "            f.write(\"\\n\")\n",
+    "\n",
+    "    print(f\"Wrote {k} examples to {model_comparison_path}\", flush=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## (Optional) Compare Generated Data\n",
+    "\n",
+    "Let's compare the outputs from the models by saving them to a markdown file for easy review."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "used_models = 0\n",
+    "\n",
+    "if 'generated_data_phi4' in locals():\n",
+    "    num_generated_data_phi4 = len(generated_data_phi4)\n",
+    "    used_models += 1\n",
+    "else:\n",
+    "    num_generated_data_phi4 = 0\n",
+    "\n",
+    "if 'generated_data_llama3' in locals():\n",
+    "    num_generated_data_llama3 = len(generated_data_llama3)\n",
+    "    used_models += 1\n",
+    "else:\n",
+    "    num_generated_data_llama3 = 0\n",
+    "\n",
+    "if 'generated_data_mixtral' in locals():\n",
+    "    num_generated_data_mixtral = len(generated_data_mixtral)\n",
+    "    used_models += 1\n",
+    "else:\n",
+    "    num_generated_data_mixtral = 0\n",
+    "\n",
+    "if used_models > 1:\n",
+    "    # Save comparison results to markdown file\n",
+    "    model_comparison_path = f\"model_comparison{_data_name_repeat}_{timestamp}.md\"\n",
+    "\n",
+    "    with open(model_comparison_path, \"w\") as f:\n",
+    "        # Number of examples to compare\n",
+    "        k = max(num_generated_data_phi4, num_generated_data_llama3, num_generated_data_mixtral)\n",
+    "\n",
+    "        # Compare generated Q&A pairs\n",
+    "        for i in range(k):\n",
+    "            f.write(f\"# Example #{i+1}\\n\\n\")\n",
+    "\n",
+    "            if i < num_generated_data_phi4:\n",
+    "                # phi4 results\n",
+    "                generated_data_i = generated_data_phi4[i]\n",
+    "                short_name = phi4_short_name\n",
+    "                print_generated_data(f, generated_data_i, short_name)\n",
+    "\n",
+    "            if i < num_generated_data_llama3:\n",
+    "                # llama3 results\n",
+    "                generated_data_i = generated_data_llama3[i]\n",
+    "                short_name = llama3_short_name\n",
+    "                print_generated_data(f, generated_data_i, short_name)\n",
+    "\n",
+    "            if i < num_generated_data_mixtral:\n",
+    "                # mixtral results\n",
+    "                generated_data_i = generated_data_mixtral[i]\n",
+    "                short_name = mixtral_short_name\n",
+    "                print_generated_data(f, generated_data_i, short_name)\n",
+    "\n",
+    "            f.write(\"\\n\")\n",
+    "\n",
+    "    print(f\"Wrote {k} examples to {model_comparison_path}\", flush=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Production Usage\n",
+    "For large-scale data generation, export this notebook to a python script and execute it.\n",
+    "\n",
+    "Or execute as follows.\n",
+    "```bash\n",
+    "python -m sdg_hub.flow_runner --ds_path seed_data.jsonl --save_path messages_data.jsonl --endpoint http://0.0.0.0:8000/v1 --flow synth_knowledge1.5_ja_phi4.yaml --checkpoint_dir Tmp\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "sdg_hub-py312",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/knowledge_tuning/data-generation-japanese/synth_knowledge1.5_ja_llama3.yaml
+++ b/examples/knowledge_tuning/data-generation-japanese/synth_knowledge1.5_ja_llama3.yaml
@@ -1,0 +1,136 @@
+- block_type: DuplicateColumns
+  block_config:
+    block_name: duplicate_document_col
+    columns_map:
+      document: base_document
+
+- block_type: LLMBlock
+  block_config:
+    block_name: gen_detailed_summary
+    config_path: configs/knowledge_ja/detailed_summary_ja.yaml
+    model_id: meta-llama/Llama-3.3-70B-Instruct
+    output_cols:
+      - summary_detailed
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: LLMBlock
+  block_config:
+    block_name: gen_atomic_facts
+    config_path: configs/knowledge_ja/atomic_facts_ja.yaml
+    model_id: meta-llama/Llama-3.3-70B-Instruct
+    output_cols:
+      - summary_atomic_facts
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: LLMBlock
+  block_config:
+    block_name: gen_extractive_summary
+    config_path: configs/knowledge_ja/extractive_summary_ja.yaml
+    model_id: meta-llama/Llama-3.3-70B-Instruct
+    output_cols:
+      - summary_extractive
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FlattenColumnsBlock
+  block_config:
+    block_name: flatten_summary_columns
+    var_cols:
+      - summary_detailed
+      - summary_extractive
+      - summary_atomic_facts
+      - base_document
+    value_name: summary
+    var_name: dataset_type
+
+- block_type: RenameColumns
+  block_config:
+    block_name: rename_to_document_column
+    columns_map:
+      document: raw_document
+      summary: document
+
+- block_type: LLMBlock
+  block_config:
+    block_name: knowledge generation
+    config_path: configs/knowledge_ja/generate_questions_responses_ja.yaml
+    model_id: meta-llama/Llama-3.3-70B-Instruct
+    output_cols:
+      - question
+      - response
+    parser_kwargs:
+      parser_name: custom
+      parsing_pattern: "\\[(?:Question|QUESTION)\\]\\s*(.*?)\\s*\\[(?:Answer|ANSWER)\\]\\s*(.*?)\\s*(?=\\[(?:Question|QUESTION)\\]|$)"
+      parser_cleanup_tags:
+        - "[END]"
+  gen_kwargs:
+    temperature: 0.0
+    max_tokens: 2048
+
+- block_type: LLMBlock
+  block_config:
+    block_name: eval_faithfulness_qa_pair
+    config_path: configs/knowledge/evaluate_faithfulness.yaml
+    model_id: meta-llama/Llama-3.3-70B-Instruct
+    output_cols:
+      - explanation
+      - judgment
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FilterByValueBlock
+  block_config:
+    block_name: filter_faithfulness
+    filter_column: judgment
+    filter_value: "YES"
+    operation: operator.eq
+  drop_columns:
+    - judgment
+    - explanation
+
+- block_type: LLMBlock
+  block_config:
+    block_name: eval_relevancy_qa_pair
+    config_path: configs/knowledge/evaluate_relevancy.yaml
+    model_id: meta-llama/Llama-3.3-70B-Instruct
+    output_cols:
+      - feedback
+      - score
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FilterByValueBlock
+  block_config:
+    block_name: filter_relevancy
+    filter_column: score
+    filter_value: 2.0
+    operation: operator.eq
+    convert_dtype: float
+  drop_columns:
+    - feedback
+    - score
+
+- block_type: LLMBlock
+  block_config:
+    block_name: eval_verify_question
+    config_path: configs/knowledge/evaluate_question.yaml
+    model_id: meta-llama/Llama-3.3-70B-Instruct
+    output_cols:
+      - explanation
+      - rating
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FilterByValueBlock
+  block_config:
+    block_name: filter_verify_question
+    filter_column: rating
+    filter_value: 1.0
+    operation: operator.eq
+    convert_dtype: float
+  drop_columns:
+    - explanation
+    - rating
+    - __index_level_0__

--- a/examples/knowledge_tuning/data-generation-japanese/synth_knowledge1.5_ja_mixtral.yaml
+++ b/examples/knowledge_tuning/data-generation-japanese/synth_knowledge1.5_ja_mixtral.yaml
@@ -1,0 +1,136 @@
+- block_type: DuplicateColumns
+  block_config:
+    block_name: duplicate_document_col
+    columns_map:
+      document: base_document
+
+- block_type: LLMBlock
+  block_config:
+    block_name: gen_detailed_summary
+    config_path: configs/knowledge_ja/detailed_summary_ja.yaml
+    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    output_cols:
+      - summary_detailed
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: LLMBlock
+  block_config:
+    block_name: gen_atomic_facts
+    config_path: configs/knowledge_ja/atomic_facts_ja.yaml
+    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    output_cols:
+      - summary_atomic_facts
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: LLMBlock
+  block_config:
+    block_name: gen_extractive_summary
+    config_path: configs/knowledge_ja/extractive_summary_ja.yaml
+    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    output_cols:
+      - summary_extractive
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FlattenColumnsBlock
+  block_config:
+    block_name: flatten_summary_columns
+    var_cols:
+      - summary_detailed
+      - summary_extractive
+      - summary_atomic_facts
+      - base_document
+    value_name: summary
+    var_name: dataset_type
+
+- block_type: RenameColumns
+  block_config:
+    block_name: rename_to_document_column
+    columns_map:
+      document: raw_document
+      summary: document
+
+- block_type: LLMBlock
+  block_config:
+    block_name: knowledge generation
+    config_path: configs/knowledge_ja/generate_questions_responses_ja.yaml
+    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    output_cols:
+      - question
+      - response
+    parser_kwargs:
+      parser_name: custom
+      parsing_pattern: "\\[(?:Question|QUESTION)\\]\\s*(.*?)\\s*\\[(?:Answer|ANSWER)\\]\\s*(.*?)\\s*(?=\\[(?:Question|QUESTION)\\]|$)"
+      parser_cleanup_tags:
+        - "[END]"
+  gen_kwargs:
+    temperature: 0.0
+    max_tokens: 2048
+
+- block_type: LLMBlock
+  block_config:
+    block_name: eval_faithfulness_qa_pair
+    config_path: configs/knowledge/evaluate_faithfulness.yaml
+    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    output_cols:
+      - explanation
+      - judgment
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FilterByValueBlock
+  block_config:
+    block_name: filter_faithfulness
+    filter_column: judgment
+    filter_value: "YES"
+    operation: operator.eq
+  drop_columns:
+    - judgment
+    - explanation
+
+- block_type: LLMBlock
+  block_config:
+    block_name: eval_relevancy_qa_pair
+    config_path: configs/knowledge/evaluate_relevancy.yaml
+    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    output_cols:
+      - feedback
+      - score
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FilterByValueBlock
+  block_config:
+    block_name: filter_relevancy
+    filter_column: score
+    filter_value: 2.0
+    operation: operator.eq
+    convert_dtype: float
+  drop_columns:
+    - feedback
+    - score
+
+- block_type: LLMBlock
+  block_config:
+    block_name: eval_verify_question
+    config_path: configs/knowledge/evaluate_question.yaml
+    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    output_cols:
+      - explanation
+      - rating
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FilterByValueBlock
+  block_config:
+    block_name: filter_verify_question
+    filter_column: rating
+    filter_value: 1.0
+    operation: operator.eq
+    convert_dtype: float
+  drop_columns:
+    - explanation
+    - rating
+    - __index_level_0__

--- a/examples/knowledge_tuning/data-generation-japanese/synth_knowledge1.5_ja_phi4.yaml
+++ b/examples/knowledge_tuning/data-generation-japanese/synth_knowledge1.5_ja_phi4.yaml
@@ -1,0 +1,136 @@
+- block_type: DuplicateColumns
+  block_config:
+    block_name: duplicate_document_col
+    columns_map:
+      document: base_document
+
+- block_type: LLMBlock
+  block_config:
+    block_name: gen_detailed_summary
+    config_path: configs/knowledge_ja/detailed_summary_ja.yaml
+    model_id: microsoft/phi-4
+    output_cols:
+      - summary_detailed
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: LLMBlock
+  block_config:
+    block_name: gen_atomic_facts
+    config_path: configs/knowledge_ja/atomic_facts_ja.yaml
+    model_id: microsoft/phi-4
+    output_cols:
+      - summary_atomic_facts
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: LLMBlock
+  block_config:
+    block_name: gen_extractive_summary
+    config_path: configs/knowledge_ja/extractive_summary_ja.yaml
+    model_id: microsoft/phi-4
+    output_cols:
+      - summary_extractive
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FlattenColumnsBlock
+  block_config:
+    block_name: flatten_summary_columns
+    var_cols:
+      - summary_detailed
+      - summary_extractive
+      - summary_atomic_facts
+      - base_document
+    value_name: summary
+    var_name: dataset_type
+
+- block_type: RenameColumns
+  block_config:
+    block_name: rename_to_document_column
+    columns_map:
+      document: raw_document
+      summary: document
+
+- block_type: LLMBlock
+  block_config:
+    block_name: knowledge generation
+    config_path: configs/knowledge_ja/generate_questions_responses_ja.yaml
+    model_id: microsoft/phi-4
+    output_cols:
+      - question
+      - response
+    parser_kwargs:
+      parser_name: custom
+      parsing_pattern: "\\[(?:Question|QUESTION)\\]\\s*(.*?)\\s*\\[(?:Answer|ANSWER)\\]\\s*(.*?)\\s*(?=\\[(?:Question|QUESTION)\\]|$)"
+      parser_cleanup_tags:
+        - "[END]"
+  gen_kwargs:
+    temperature: 0.0
+    max_tokens: 2048
+
+- block_type: LLMBlock
+  block_config:
+    block_name: eval_faithfulness_qa_pair
+    config_path: configs/knowledge/evaluate_faithfulness.yaml
+    model_id: microsoft/phi-4
+    output_cols:
+      - explanation
+      - judgment
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FilterByValueBlock
+  block_config:
+    block_name: filter_faithfulness
+    filter_column: judgment
+    filter_value: "YES"
+    operation: operator.eq
+  drop_columns:
+    - judgment
+    - explanation
+
+- block_type: LLMBlock
+  block_config:
+    block_name: eval_relevancy_qa_pair
+    config_path: configs/knowledge/evaluate_relevancy.yaml
+    model_id: microsoft/phi-4
+    output_cols:
+      - feedback
+      - score
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FilterByValueBlock
+  block_config:
+    block_name: filter_relevancy
+    filter_column: score
+    filter_value: 2.0
+    operation: operator.eq
+    convert_dtype: float
+  drop_columns:
+    - feedback
+    - score
+
+- block_type: LLMBlock
+  block_config:
+    block_name: eval_verify_question
+    config_path: configs/knowledge/evaluate_question.yaml
+    model_id: microsoft/phi-4
+    output_cols:
+      - explanation
+      - rating
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FilterByValueBlock
+  block_config:
+    block_name: filter_verify_question
+    filter_column: rating
+    filter_value: 1.0
+    operation: operator.eq
+    convert_dtype: float
+  drop_columns:
+    - explanation
+    - rating
+    - __index_level_0__

--- a/examples/knowledge_tuning/data-generation-japanese/synth_knowledge1.5_llama3.yaml
+++ b/examples/knowledge_tuning/data-generation-japanese/synth_knowledge1.5_llama3.yaml
@@ -1,0 +1,136 @@
+- block_type: DuplicateColumns
+  block_config:
+    block_name: duplicate_document_col
+    columns_map:
+      document: base_document
+
+- block_type: LLMBlock
+  block_config:
+    block_name: gen_detailed_summary
+    config_path: configs/knowledge/detailed_summary.yaml
+    model_id: meta-llama/Llama-3.3-70B-Instruct
+    output_cols:
+      - summary_detailed
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: LLMBlock
+  block_config:
+    block_name: gen_atomic_facts
+    config_path: configs/knowledge/atomic_facts.yaml
+    model_id: meta-llama/Llama-3.3-70B-Instruct
+    output_cols:
+      - summary_atomic_facts
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: LLMBlock
+  block_config:
+    block_name: gen_extractive_summary
+    config_path: configs/knowledge/extractive_summary.yaml
+    model_id: meta-llama/Llama-3.3-70B-Instruct
+    output_cols:
+      - summary_extractive
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FlattenColumnsBlock
+  block_config:
+    block_name: flatten_summary_columns
+    var_cols:
+      - summary_detailed
+      - summary_extractive
+      - summary_atomic_facts
+      - base_document
+    value_name: summary
+    var_name: dataset_type
+
+- block_type: RenameColumns
+  block_config:
+    block_name: rename_to_document_column
+    columns_map:
+      document: raw_document
+      summary: document
+
+- block_type: LLMBlock
+  block_config:
+    block_name: knowledge generation
+    config_path: configs/knowledge/generate_questions_responses.yaml
+    model_id: meta-llama/Llama-3.3-70B-Instruct
+    output_cols:
+      - question
+      - response
+    parser_kwargs:
+      parser_name: custom
+      parsing_pattern: "\\[(?:Question|QUESTION)\\]\\s*(.*?)\\s*\\[(?:Answer|ANSWER)\\]\\s*(.*?)\\s*(?=\\[(?:Question|QUESTION)\\]|$)"
+      parser_cleanup_tags:
+        - "[END]"
+  gen_kwargs:
+    temperature: 0.0
+    max_tokens: 2048
+
+- block_type: LLMBlock
+  block_config:
+    block_name: eval_faithfulness_qa_pair
+    config_path: configs/knowledge/evaluate_faithfulness.yaml
+    model_id: meta-llama/Llama-3.3-70B-Instruct
+    output_cols:
+      - explanation
+      - judgment
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FilterByValueBlock
+  block_config:
+    block_name: filter_faithfulness
+    filter_column: judgment
+    filter_value: "YES"
+    operation: operator.eq
+  drop_columns:
+    - judgment
+    - explanation
+
+- block_type: LLMBlock
+  block_config:
+    block_name: eval_relevancy_qa_pair
+    config_path: configs/knowledge/evaluate_relevancy.yaml
+    model_id: meta-llama/Llama-3.3-70B-Instruct
+    output_cols:
+      - feedback
+      - score
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FilterByValueBlock
+  block_config:
+    block_name: filter_relevancy
+    filter_column: score
+    filter_value: 2.0
+    operation: operator.eq
+    convert_dtype: float
+  drop_columns:
+    - feedback
+    - score
+
+- block_type: LLMBlock
+  block_config:
+    block_name: eval_verify_question
+    config_path: configs/knowledge/evaluate_question.yaml
+    model_id: meta-llama/Llama-3.3-70B-Instruct
+    output_cols:
+      - explanation
+      - rating
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FilterByValueBlock
+  block_config:
+    block_name: filter_verify_question
+    filter_column: rating
+    filter_value: 1.0
+    operation: operator.eq
+    convert_dtype: float
+  drop_columns:
+    - explanation
+    - rating
+    - __index_level_0__

--- a/examples/knowledge_tuning/data-generation-japanese/synth_knowledge1.5_mixtral.yaml
+++ b/examples/knowledge_tuning/data-generation-japanese/synth_knowledge1.5_mixtral.yaml
@@ -1,0 +1,136 @@
+- block_type: DuplicateColumns
+  block_config:
+    block_name: duplicate_document_col
+    columns_map:
+      document: base_document
+
+- block_type: LLMBlock
+  block_config:
+    block_name: gen_detailed_summary
+    config_path: configs/knowledge/detailed_summary.yaml
+    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    output_cols:
+      - summary_detailed
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: LLMBlock
+  block_config:
+    block_name: gen_atomic_facts
+    config_path: configs/knowledge/atomic_facts.yaml
+    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    output_cols:
+      - summary_atomic_facts
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: LLMBlock
+  block_config:
+    block_name: gen_extractive_summary
+    config_path: configs/knowledge/extractive_summary.yaml
+    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    output_cols:
+      - summary_extractive
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FlattenColumnsBlock
+  block_config:
+    block_name: flatten_summary_columns
+    var_cols:
+      - summary_detailed
+      - summary_extractive
+      - summary_atomic_facts
+      - base_document
+    value_name: summary
+    var_name: dataset_type
+
+- block_type: RenameColumns
+  block_config:
+    block_name: rename_to_document_column
+    columns_map:
+      document: raw_document
+      summary: document
+
+- block_type: LLMBlock
+  block_config:
+    block_name: knowledge generation
+    config_path: configs/knowledge/generate_questions_responses.yaml
+    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    output_cols:
+      - question
+      - response
+    parser_kwargs:
+      parser_name: custom
+      parsing_pattern: "\\[(?:Question|QUESTION)\\]\\s*(.*?)\\s*\\[(?:Answer|ANSWER)\\]\\s*(.*?)\\s*(?=\\[(?:Question|QUESTION)\\]|$)"
+      parser_cleanup_tags:
+        - "[END]"
+  gen_kwargs:
+    temperature: 0.0
+    max_tokens: 2048
+
+- block_type: LLMBlock
+  block_config:
+    block_name: eval_faithfulness_qa_pair
+    config_path: configs/knowledge/evaluate_faithfulness.yaml
+    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    output_cols:
+      - explanation
+      - judgment
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FilterByValueBlock
+  block_config:
+    block_name: filter_faithfulness
+    filter_column: judgment
+    filter_value: "YES"
+    operation: operator.eq
+  drop_columns:
+    - judgment
+    - explanation
+
+- block_type: LLMBlock
+  block_config:
+    block_name: eval_relevancy_qa_pair
+    config_path: configs/knowledge/evaluate_relevancy.yaml
+    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    output_cols:
+      - feedback
+      - score
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FilterByValueBlock
+  block_config:
+    block_name: filter_relevancy
+    filter_column: score
+    filter_value: 2.0
+    operation: operator.eq
+    convert_dtype: float
+  drop_columns:
+    - feedback
+    - score
+
+- block_type: LLMBlock
+  block_config:
+    block_name: eval_verify_question
+    config_path: configs/knowledge/evaluate_question.yaml
+    model_id: mistralai/Mixtral-8x7B-Instruct-v0.1
+    output_cols:
+      - explanation
+      - rating
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FilterByValueBlock
+  block_config:
+    block_name: filter_verify_question
+    filter_column: rating
+    filter_value: 1.0
+    operation: operator.eq
+    convert_dtype: float
+  drop_columns:
+    - explanation
+    - rating
+    - __index_level_0__

--- a/examples/knowledge_tuning/data-generation-japanese/synth_knowledge1.5_phi4.yaml
+++ b/examples/knowledge_tuning/data-generation-japanese/synth_knowledge1.5_phi4.yaml
@@ -1,0 +1,136 @@
+- block_type: DuplicateColumns
+  block_config:
+    block_name: duplicate_document_col
+    columns_map:
+      document: base_document
+
+- block_type: LLMBlock
+  block_config:
+    block_name: gen_detailed_summary
+    config_path: configs/knowledge/detailed_summary.yaml
+    model_id: microsoft/phi-4
+    output_cols:
+      - summary_detailed
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: LLMBlock
+  block_config:
+    block_name: gen_atomic_facts
+    config_path: configs/knowledge/atomic_facts.yaml
+    model_id: microsoft/phi-4
+    output_cols:
+      - summary_atomic_facts
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: LLMBlock
+  block_config:
+    block_name: gen_extractive_summary
+    config_path: configs/knowledge/extractive_summary.yaml
+    model_id: microsoft/phi-4
+    output_cols:
+      - summary_extractive
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FlattenColumnsBlock
+  block_config:
+    block_name: flatten_summary_columns
+    var_cols:
+      - summary_detailed
+      - summary_extractive
+      - summary_atomic_facts
+      - base_document
+    value_name: summary
+    var_name: dataset_type
+
+- block_type: RenameColumns
+  block_config:
+    block_name: rename_to_document_column
+    columns_map:
+      document: raw_document
+      summary: document
+
+- block_type: LLMBlock
+  block_config:
+    block_name: knowledge generation
+    config_path: configs/knowledge/generate_questions_responses.yaml
+    model_id: microsoft/phi-4
+    output_cols:
+      - question
+      - response
+    parser_kwargs:
+      parser_name: custom
+      parsing_pattern: "\\[(?:Question|QUESTION)\\]\\s*(.*?)\\s*\\[(?:Answer|ANSWER)\\]\\s*(.*?)\\s*(?=\\[(?:Question|QUESTION)\\]|$)"
+      parser_cleanup_tags:
+        - "[END]"
+  gen_kwargs:
+    temperature: 0.0
+    max_tokens: 2048
+
+- block_type: LLMBlock
+  block_config:
+    block_name: eval_faithfulness_qa_pair
+    config_path: configs/knowledge/evaluate_faithfulness.yaml
+    model_id: microsoft/phi-4
+    output_cols:
+      - explanation
+      - judgment
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FilterByValueBlock
+  block_config:
+    block_name: filter_faithfulness
+    filter_column: judgment
+    filter_value: "YES"
+    operation: operator.eq
+  drop_columns:
+    - judgment
+    - explanation
+
+- block_type: LLMBlock
+  block_config:
+    block_name: eval_relevancy_qa_pair
+    config_path: configs/knowledge/evaluate_relevancy.yaml
+    model_id: microsoft/phi-4
+    output_cols:
+      - feedback
+      - score
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FilterByValueBlock
+  block_config:
+    block_name: filter_relevancy
+    filter_column: score
+    filter_value: 2.0
+    operation: operator.eq
+    convert_dtype: float
+  drop_columns:
+    - feedback
+    - score
+
+- block_type: LLMBlock
+  block_config:
+    block_name: eval_verify_question
+    config_path: configs/knowledge/evaluate_question.yaml
+    model_id: microsoft/phi-4
+    output_cols:
+      - explanation
+      - rating
+  gen_kwargs:
+    max_tokens: 2048
+
+- block_type: FilterByValueBlock
+  block_config:
+    block_name: filter_verify_question
+    filter_column: rating
+    filter_value: 1.0
+    operation: operator.eq
+    convert_dtype: float
+  drop_columns:
+    - explanation
+    - rating
+    - __index_level_0__

--- a/src/sdg_hub/configs/knowledge_ja/atomic_facts_ja.yaml
+++ b/src/sdg_hub/configs/knowledge_ja/atomic_facts_ja.yaml
@@ -1,0 +1,47 @@
+system: You are an AI assistant knowledgeable about {{domain}} domain. Be accurate but concise in response.
+
+introduction: | 
+  Please break down the following snippet from an article about {{domain}} into atomic facts.
+
+principles: |
+  1. Make sure each fact is grounded in the given text.
+  2. Include any necessary information needed to explain the fact or concept
+  3. The atomic facts should be as simple as possible, if it’s compound sentence, break down one more time
+  4. For clarity, avoid using pronouns like ’it’, ’he’, ’she’, ’this’, ’that’ etc., and instead use the full names or titles.
+  5. Focus only on key concepts and facts. Skip any question or problems mentioned in the passage.
+  6. Output the response in Japanese.
+
+examples: |
+  To help you understand the task, here is an example:
+  [Passage]
+  The tournament was contested by ten national teams, maintaining the same format used in 2019. After six weeks of round-robin matches, India, South Africa, Australia, and New Zealand finished as the top four and qualified for the knockout stage. In the knockout stage, India and Australia beat New Zealand and South Africa, respectively, to advance to the final, played on 19 November at the Narendra Modi Stadium in Ahmedabad. Australia won the final by six wickets, winning their sixth Cricket World Cup title.
+  [Facts]
+  1. The tournament was contested by ten national teams.
+  2. The tournament maintained the same format used in 2019.
+  3. The round-robin matches lasted for six weeks.
+  4. India finished as one of the top four teams.
+  5. South Africa finished as one of the top four teams.
+  6. Australia finished as one of the top four teams.
+  7. New Zealand finished as one of the top four teams.
+  8. India, South Africa, Australia, and New Zealand qualified for the knockout stage.
+  9. In the knockout stage, India beat New Zealand.
+  10. In the knockout stage, Australia beat South Africa.
+  11. India advanced to the final.
+  12. Australia advanced to the final.
+  13. The final was played on 19 November.
+  14. The final was held at the Narendra Modi Stadium in Ahmedabad.
+  15. Australia won the final by six wickets.
+  16. Australia won their sixth Cricket World Cup title.
+  [End]
+
+
+generation: |
+  Now it's your turn breakdown following snippet from article about {{domain}} into atomic facts following similar style as above examples
+  [Passage]
+  {{document_outline}}
+  {{document}}
+  [Facts]
+
+
+start_tags: [""]
+end_tags: [""]

--- a/src/sdg_hub/configs/knowledge_ja/detailed_summary_ja.yaml
+++ b/src/sdg_hub/configs/knowledge_ja/detailed_summary_ja.yaml
@@ -1,0 +1,19 @@
+system: You are an AI assistant that is expert at summarizing text.
+
+introduction: |
+  Give me detailed summary for below document, making sure all key points are covered.
+
+principles: |
+  Do not add any new information.
+  Do not miss any key points from the provided document.
+  Output the response in Japanese.
+
+examples: ""
+
+generation: |
+  Document:
+  {{document_outline}}
+  {{document}}
+
+start_tags: [""]
+end_tags: [""]

--- a/src/sdg_hub/configs/knowledge_ja/extractive_summary_ja.yaml
+++ b/src/sdg_hub/configs/knowledge_ja/extractive_summary_ja.yaml
@@ -1,0 +1,19 @@
+system: You are an AI assistant that is expert at summarizing text.
+
+introduction: |
+  Give me detailed extractive summary for below document, making sure all key points are covered.
+
+principles: |
+  Do not add any new information.
+  Do not miss any key points from the provided document.
+  Output the response in Japanese.
+
+examples: ""
+
+generation: |
+  Document:
+  {{document_outline}}
+  {{document}}
+
+start_tags: [""]
+end_tags: [""]

--- a/src/sdg_hub/configs/knowledge_ja/generate_questions_responses_ja.yaml
+++ b/src/sdg_hub/configs/knowledge_ja/generate_questions_responses_ja.yaml
@@ -1,0 +1,57 @@
+system: You are a very knowledgeable AI Assistant that will faithfully assist the user with their task.
+
+introduction: Develop a series of as many educational question and answer pairs as possible from a chapter in a {{domain}} textbook. 
+
+principles: |
+  The questions should:
+  * Be self-contained, not requiring references to tables, figures, or specific sections in the text for understanding.
+  * Focus on teaching and reinforcing the key knowledge and concepts presented in the chapter.
+  * Avoid sections with minimal educational content like index pages or prefaces. In such cases, respond with [UNANSWERABLE].
+  * Be directly relevant to the textbook's domain. For instance, in a science textbook, questions should revolve around scientific terms, definitions, and practical applications, while in a legal textbook, they should cover legal principles, case law, and precedents.
+  * Be formulated to allow for independent answers, avoiding direct references to specific theorems or text sections. For example, rather than asking 'Under what conditions is the fixed point of a function unique according to Theorem 3.1.5?', ask 'How does the Fixed Point Iteration method contribute to understanding function uniqueness?'
+  * Span a range of difficulty levels to accommodate a diverse student audience, from basic understanding to advanced comprehension.
+  * Include a variety of question types such as multiple-choice for basic recall, short answer for deeper understanding, and essay or problem-solving questions to test application and analysis skills.
+  * Align closely with the learning objectives of the textbook or the specific chapter, ensuring that the questions test the fundamental concepts and skills that the chapter aims to impart.
+  * Output the response in Japanese.
+
+  Strictly follow this format for each question answer pair your generate while responding
+
+  [QUESTION]
+  <Insert question here>
+  [ANSWER]
+  <Insert answer here>
+  [END]
+
+
+  Each question and answer pair should stand alone as a mini-lesson, encapsulating a key concept or idea from the chapter in a way that is accessible and informative without requiring the reader to refer back to the textbook.
+
+examples: |
+  Here are some examples of questions:
+
+  [Document]
+  {{icl_document}}
+
+  [QUESTION]
+  {{icl_query_1}}
+  [ANSWER]
+  {{icl_response_1}}
+  [END]
+
+  [QUESTION]
+  {{icl_query_2}}
+  [ANSWER]
+  {{icl_response_2}}
+  [END]
+
+  [QUESTION]
+  {{icl_query_3}}
+  [ANSWER]
+  {{icl_response_3}}
+  [END]
+
+generation: |
+  Here is the document:
+  
+  [DOCUMENT]
+  {{document_outline}}
+  {{document}}


### PR DESCRIPTION
This is a knowledge SDG tutorial for Japanese documents. It is based on the existing knowledge SDG tutorial for English documents (data-generation-with-llama-70b), with minimum changes described below.
- Used phi-4 as the teacher model
- Updated prompt templates as follows
  - Added "Output the response in Japanese" (to ensure the Japanese output)
  - Added "as many ... as possible" (to squeeze the knowledge from the document)