### PR TITLE
Fix pre-processing tutorial

### DIFF
--- a/examples/knowledge_tuning/instructlab/.gitignore
+++ b/examples/knowledge_tuning/instructlab/.gitignore
@@ -1,0 +1,1 @@
+sdg_demo_output*/

--- a/examples/knowledge_tuning/instructlab/docling_v2_config.yaml
+++ b/examples/knowledge_tuning/instructlab/docling_v2_config.yaml
@@ -1,0 +1,19 @@
+export:
+  formats:
+    doctags: false
+    html: false
+    json: false
+    markdown: true
+    text: false
+pipeline:
+  ocr:
+    enabled: true
+    languages:
+    - en
+    - ja
+  performance:
+    device: auto
+    threads: 4
+  tables:
+    cell_matching: true
+    enabled: true

--- a/examples/knowledge_tuning/instructlab/docling_v2_config_no_ocr.yaml
+++ b/examples/knowledge_tuning/instructlab/docling_v2_config_no_ocr.yaml
@@ -1,0 +1,17 @@
+export:
+  formats:
+    doctags: false
+    html: false
+    json: false
+    markdown: true
+    text: false
+pipeline:
+  ocr:
+    enabled: false
+    languages: []
+  performance:
+    device: auto
+    threads: 4
+  tables:
+    cell_matching: true
+    enabled: true

--- a/examples/knowledge_tuning/instructlab/docparser_v2.py
+++ b/examples/knowledge_tuning/instructlab/docparser_v2.py
@@ -35,7 +35,7 @@ from docling.document_converter import DocumentConverter, PdfFormatOption
 from docling.models.ocr_mac_model import OcrMacOptions
 from docling.models.tesseract_ocr_cli_model import TesseractCliOcrOptions
 from docling.models.tesseract_ocr_model import TesseractOcrOptions
-from logger_config import setup_logger
+from sdg_hub.logger_config import setup_logger
 import click
 
 logger = setup_logger(__name__)

--- a/examples/knowledge_tuning/instructlab/document_pre_processing.ipynb
+++ b/examples/knowledge_tuning/instructlab/document_pre_processing.ipynb
@@ -17,8 +17,7 @@
     "### Install SDG\n",
     "\n",
     "```bash \n",
-    "pip install sdg-hub==0.1.0a2\n",
-    "pip install rich datasets tabulate transformers\n",
+    "pip install sdg-hub[examples]\n",
     "```"
    ]
   },
@@ -35,8 +34,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_dir = 'document_collection/ibm-annual-report'\n",
-    "!OMP_NUM_THREADS=32 mamba run -n docling python ../scripts/docparser.py --input-dir {data_dir} --output-dir {data_dir}"
+    "# data_dir = 'document_collection/ibm-annual-report'\n",
+    "# !OMP_NUM_THREADS=32 mamba run -n docling python ../scripts/docparser.py --input-dir {data_dir} --output-dir {data_dir}"
    ]
   },
   {
@@ -53,7 +52,8 @@
    "outputs": [],
    "source": [
     "data_dir = 'document_collection/ibm-annual-report'\n",
-    "!OMP_NUM_THREADS=32 mamba run -n docling python ../scripts/docparser_v2.py --input-dir {data_dir} --output-dir {data_dir} --c docling_v2_config.yaml"
+    "# !OMP_NUM_THREADS=32 mamba run -n docling python ../scripts/docparser_v2.py --input-dir {data_dir} --output-dir {data_dir} --c docling_v2_config.yaml\n",
+    "!python docparser_v2.py --input-dir {data_dir} --output-dir {data_dir} -c docling_v2_config.yaml"
    ]
   },
   {
@@ -69,16 +69,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from utils import DocProcessor\n",
+    "from knowledge_utils import DocProcessor\n",
     "\n",
     "output_dir = f\"sdg_demo_output/\"\n",
     "# This is where your PDFs are stored\n",
-    "data_dir = '../document_collection/ibm-annual-report' \n",
+    "# data_dir = '../document_collection/ibm-annual-report' \n",
     "# It also have your QNA yaml file\n",
     "dp = DocProcessor(data_dir, user_config_path=f'{data_dir}/qna.yaml')\n",
     "\n",
     "### Using docling v1 json\n",
-    "seed_data = dp.get_processed_dataset()\n",
+    "# seed_data = dp.get_processed_dataset()\n",
     "\n",
     "### Using markdown file\n",
     "seed_data = dp.get_processed_markdown_dataset([f\"{data_dir}/ibm-annual-report-2024.md\"])\n",
@@ -91,7 +91,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "research_sdg",
+   "display_name": "sdg_hub-py312",
    "language": "python",
    "name": "python3"
   },
@@ -105,7 +105,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.16"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,

--- a/examples/knowledge_tuning/instructlab/knowledge_utils.py
+++ b/examples/knowledge_tuning/instructlab/knowledge_utils.py
@@ -1,0 +1,1 @@
+../knowledge_utils.py


### PR DESCRIPTION
Fixing the existing pre-processing tutorial with minimum changes described below.
- Comment-out docling v1 code
- Add docling v2 config files for English and Japanese documents
- Fix import errors in docparser_v2.py
