### PR TITLE
Add EvaluateFaithfulnessBlock composite evaluation block

### DIFF
--- a/src/sdg_hub/blocks/__init__.py
+++ b/src/sdg_hub/blocks/__init__.py
@@ -26,6 +26,7 @@ from .transform import (
     TextConcatBlock,
     UniformColumnValueSetter,
 )
+from .evaluation import EvaluateFaithfulnessBlock
 # All blocks moved to deprecated_blocks or transform modules
 
 __all__ = [
@@ -49,4 +50,5 @@ __all__ = [
     "TextParserBlock",
     "BlockRegistry",
     "PromptBuilderBlock",
+    "EvaluateFaithfulnessBlock",
 ]

--- a/src/sdg_hub/blocks/evaluation/__init__.py
+++ b/src/sdg_hub/blocks/evaluation/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Evaluation blocks for SDG Hub."""
+
+from .evaluate_faithfulness_block import EvaluateFaithfulnessBlock
+
+__all__ = ["EvaluateFaithfulnessBlock"]

--- a/src/sdg_hub/blocks/evaluation/evaluate_faithfulness_block.py
+++ b/src/sdg_hub/blocks/evaluation/evaluate_faithfulness_block.py
@@ -1,0 +1,455 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Composite block for faithfulness evaluation of question-answer pairs.
+
+This module provides the EvaluateFaithfulnessBlock that encapsulates the complete
+faithfulness evaluation workflow, combining prompt building, LLM chat, text parsing,
+and filtering into a single block for simplified configuration.
+"""
+
+# Standard
+from typing import Any, Dict, List, Optional, Union
+
+# Third Party
+from datasets import Dataset
+from pydantic import Field, field_validator
+
+# Local
+from ...logger_config import setup_logger
+from ..base import BaseBlock
+from ..registry import BlockRegistry
+from ..llm.prompt_builder_block import PromptBuilderBlock
+from ..llm.llm_chat_block import LLMChatBlock
+from ..llm.text_parser_block import TextParserBlock
+from ..filtering.column_value_filter import ColumnValueFilterBlock
+
+logger = setup_logger(__name__)
+
+
+@BlockRegistry.register(
+    "EvaluateFaithfulnessBlock",
+    "evaluation",
+    "Composite block for faithfulness evaluation of question-answer pairs",
+)
+class EvaluateFaithfulnessBlock(BaseBlock):
+    """Composite block for faithfulness evaluation workflow.
+
+    This block combines four separate blocks into a single cohesive evaluation block:
+    1. PromptBuilderBlock - builds evaluation prompt from document and response
+    2. LLMChatBlock - generates faithfulness evaluation using LLM
+    3. TextParserBlock - parses explanation and judgment from raw output
+    4. ColumnValueFilterBlock - filters based on faithfulness judgment
+
+    Parameters
+    ----------
+    block_name : str
+        Name of the block.
+    input_cols : List[str]
+        Input columns: ["document", "response"]
+    output_cols : List[str]
+        Output columns: ["faithfulness_explanation", "faithfulness_judgment", "filtered_faithfulness"]
+    prompt_config_path : str
+        Path to YAML file containing the faithfulness evaluation prompt template.
+    model : str
+        Model identifier in LiteLLM format (e.g., "hosted_vllm/meta-llama/Llama-3.3-70B-Instruct")
+    api_base : Optional[str]
+        Base URL for the API. Required for local models.
+    api_key : Optional[str]
+        API key for the provider. Falls back to environment variables.
+    filter_value : str, optional
+        Value to filter on for faithfulness judgment (default: "YES")
+    operation : str, optional
+        Filter operation (default: "eq")
+    convert_dtype : Optional[str], optional
+        Data type conversion for filter column (default: None)
+    async_mode : bool, optional
+        Whether to use async processing (default: True)
+    format_as_messages : bool, optional
+        Whether to format prompt as messages (default: True)
+    start_tags : List[str], optional
+        Start tags for parsing (default: ["[Start of Explanation]", "[Start of Answer]"])
+    end_tags : List[str], optional
+        End tags for parsing (default: ["[End of Explanation]", "[End of Answer]"])
+
+    ### LLM Generation Parameters ###
+    temperature : Optional[float], optional
+        Sampling temperature (0.0 to 2.0).
+    max_tokens : Optional[int], optional
+        Maximum tokens to generate.
+    top_p : Optional[float], optional
+        Nucleus sampling parameter (0.0 to 1.0).
+    frequency_penalty : Optional[float], optional
+        Frequency penalty (-2.0 to 2.0).
+    presence_penalty : Optional[float], optional
+        Presence penalty (-2.0 to 2.0).
+    stop : Optional[Union[str, List[str]]], optional
+        Stop sequences.
+    seed : Optional[int], optional
+        Random seed for reproducible outputs.
+    timeout : float, optional
+        Request timeout in seconds (default: 120.0).
+    max_retries : int, optional
+        Maximum number of retry attempts (default: 6).
+    """
+
+    # Core configuration
+    prompt_config_path: str = Field(
+        ...,
+        description="Path to YAML file containing the faithfulness evaluation prompt template",
+    )
+    model: str = Field(..., description="Model identifier in LiteLLM format")
+    api_base: Optional[str] = Field(None, description="Base URL for the API")
+    api_key: Optional[str] = Field(
+        None,
+        description="API key for the provider. Falls back to environment variables.",
+    )
+
+    # Filter configuration
+    filter_value: str = Field(
+        "YES", description="Value to filter on for faithfulness judgment"
+    )
+    operation: str = Field("eq", description="Filter operation")
+    convert_dtype: Optional[str] = Field(
+        None, description="Data type conversion for filter column"
+    )
+
+    # Processing configuration
+    async_mode: bool = Field(True, description="Whether to use async processing")
+    format_as_messages: bool = Field(
+        True, description="Whether to format prompt as messages"
+    )
+
+    # Parser configuration
+    start_tags: List[str] = Field(
+        ["[Start of Explanation]", "[Start of Answer]"],
+        description="Start tags for parsing explanation and judgment",
+    )
+    end_tags: List[str] = Field(
+        ["[End of Explanation]", "[End of Answer]"],
+        description="End tags for parsing explanation and judgment",
+    )
+
+    # LLM generation parameters
+    temperature: Optional[float] = Field(
+        None, description="Sampling temperature (0.0 to 2.0)"
+    )
+    max_tokens: Optional[int] = Field(None, description="Maximum tokens to generate")
+    top_p: Optional[float] = Field(
+        None, description="Nucleus sampling parameter (0.0 to 1.0)"
+    )
+    frequency_penalty: Optional[float] = Field(
+        None, description="Frequency penalty (-2.0 to 2.0)"
+    )
+    presence_penalty: Optional[float] = Field(
+        None, description="Presence penalty (-2.0 to 2.0)"
+    )
+    stop: Optional[Union[str, List[str]]] = Field(None, description="Stop sequences")
+    seed: Optional[int] = Field(
+        None, description="Random seed for reproducible outputs"
+    )
+    timeout: float = Field(120.0, description="Request timeout in seconds")
+    max_retries: int = Field(6, description="Maximum number of retry attempts")
+
+    # Internal blocks - excluded from serialization
+    prompt_builder: Optional[PromptBuilderBlock] = Field(None, exclude=True)
+    llm_chat: Optional[LLMChatBlock] = Field(None, exclude=True)
+    text_parser: Optional[TextParserBlock] = Field(None, exclude=True)
+    filter_block: Optional[ColumnValueFilterBlock] = Field(None, exclude=True)
+
+    @field_validator("input_cols")
+    @classmethod
+    def validate_input_cols(cls, v):
+        """Validate that input columns are exactly ["document", "response"]."""
+        expected = ["document", "response"]
+        if v != expected:
+            raise ValueError(
+                f"EvaluateFaithfulnessBlock expects input_cols={expected}, got {v}"
+            )
+        return v
+
+    @field_validator("output_cols")
+    @classmethod
+    def validate_output_cols(cls, v):
+        """Validate that output columns are exactly ["faithfulness_explanation", "faithfulness_judgment", "filtered_faithfulness"]."""
+        expected = [
+            "faithfulness_explanation",
+            "faithfulness_judgment",
+            "filtered_faithfulness",
+        ]
+        if v != expected:
+            raise ValueError(
+                f"EvaluateFaithfulnessBlock expects output_cols={expected}, got {v}"
+            )
+        return v
+
+    def model_post_init(self, __context: Any) -> None:
+        """Initialize the internal blocks after Pydantic validation."""
+        super().model_post_init(__context)
+
+        # Create internal blocks
+        self._create_internal_blocks()
+
+        logger.info(
+            f"Initialized EvaluateFaithfulnessBlock '{self.block_name}' with model '{self.model}'",
+            extra={
+                "block_name": self.block_name,
+                "model": self.model,
+                "async_mode": self.async_mode,
+                "filter_value": self.filter_value,
+            },
+        )
+
+    def _create_internal_blocks(self) -> None:
+        """Create and configure the internal blocks."""
+        # 1. PromptBuilderBlock
+        self.prompt_builder = PromptBuilderBlock(
+            block_name=f"{self.block_name}_prompt_builder",
+            input_cols=["document", "response"],
+            output_cols=["eval_faithfulness_prompt"],
+            prompt_config_path=self.prompt_config_path,
+            format_as_messages=self.format_as_messages,
+        )
+
+        # 2. LLMChatBlock
+        llm_kwargs = {
+            "block_name": f"{self.block_name}_llm_chat",
+            "input_cols": ["eval_faithfulness_prompt"],
+            "output_cols": ["raw_eval_faithfulness"],
+            "model": self.model,
+            "api_base": self.api_base,
+            "api_key": self.api_key,
+            "async_mode": self.async_mode,
+            "timeout": self.timeout,
+            "max_retries": self.max_retries,
+        }
+
+        # Add generation parameters if specified
+        if self.temperature is not None:
+            llm_kwargs["temperature"] = self.temperature
+        if self.max_tokens is not None:
+            llm_kwargs["max_tokens"] = self.max_tokens
+        if self.top_p is not None:
+            llm_kwargs["top_p"] = self.top_p
+        if self.frequency_penalty is not None:
+            llm_kwargs["frequency_penalty"] = self.frequency_penalty
+        if self.presence_penalty is not None:
+            llm_kwargs["presence_penalty"] = self.presence_penalty
+        if self.stop is not None:
+            llm_kwargs["stop"] = self.stop
+        if self.seed is not None:
+            llm_kwargs["seed"] = self.seed
+
+        self.llm_chat = LLMChatBlock(**llm_kwargs)
+
+        # 3. TextParserBlock
+        self.text_parser = TextParserBlock(
+            block_name=f"{self.block_name}_text_parser",
+            input_cols=["raw_eval_faithfulness"],
+            output_cols=["faithfulness_explanation", "faithfulness_judgment"],
+            start_tags=self.start_tags,
+            end_tags=self.end_tags,
+        )
+
+        # 4. ColumnValueFilterBlock
+        filter_kwargs = {
+            "block_name": f"{self.block_name}_filter",
+            "input_cols": ["faithfulness_judgment"],
+            "output_cols": [],  # Filter blocks don't create new columns
+            "filter_value": self.filter_value,
+            "operation": self.operation,
+        }
+
+        if self.convert_dtype is not None:
+            filter_kwargs["convert_dtype"] = self.convert_dtype
+
+        self.filter_block = ColumnValueFilterBlock(**filter_kwargs)
+
+    def generate(self, samples: Dataset, **kwargs: Any) -> Dataset:
+        """Generate faithfulness evaluation for all samples.
+
+        This method chains the four internal blocks in sequence:
+        1. Build faithfulness evaluation prompts
+        2. Generate LLM responses
+        3. Parse explanation and judgment
+        4. Filter based on judgment
+
+        Parameters
+        ----------
+        samples : Dataset
+            Input dataset containing 'document' and 'response' columns.
+        **kwargs : Any
+            Additional keyword arguments passed to internal blocks.
+
+        Returns
+        -------
+        Dataset
+            Dataset with faithfulness evaluation results and filtering applied.
+        """
+        logger.info(
+            f"Starting faithfulness evaluation for {len(samples)} samples",
+            extra={
+                "block_name": self.block_name,
+                "model": self.model,
+                "batch_size": len(samples),
+            },
+        )
+
+        current_dataset = samples
+
+        try:
+            # Step 1: Build prompts
+            logger.debug(f"Step 1: Building faithfulness evaluation prompts")
+            current_dataset = self.prompt_builder.generate(current_dataset, **kwargs)
+
+            # Step 2: Generate LLM responses
+            logger.debug(f"Step 2: Generating LLM responses")
+            current_dataset = self.llm_chat.generate(current_dataset, **kwargs)
+
+            # Step 3: Parse responses
+            logger.debug(f"Step 3: Parsing faithfulness evaluation responses")
+            current_dataset = self.text_parser.generate(current_dataset, **kwargs)
+
+            # Step 4: Filter based on judgment
+            logger.debug(f"Step 4: Filtering based on faithfulness judgment")
+            original_count = len(current_dataset)
+            current_dataset = self.filter_block.generate(current_dataset, **kwargs)
+            filtered_count = len(current_dataset)
+
+            # Add filtered_faithfulness column to indicate filtering was applied
+            current_dataset = current_dataset.add_column(
+                "filtered_faithfulness", [True] * filtered_count
+            )
+
+            logger.info(
+                f"Faithfulness evaluation completed: {original_count} → {filtered_count} samples "
+                f"(filtered {original_count - filtered_count} samples)",
+                extra={
+                    "block_name": self.block_name,
+                    "original_count": original_count,
+                    "filtered_count": filtered_count,
+                    "filter_rate": (original_count - filtered_count) / original_count
+                    if original_count > 0
+                    else 0,
+                },
+            )
+
+            return current_dataset
+
+        except Exception as e:
+            logger.error(
+                f"Error during faithfulness evaluation: {e}",
+                extra={
+                    "block_name": self.block_name,
+                    "model": self.model,
+                    "error": str(e),
+                },
+            )
+            raise
+
+    def _validate_custom(self, dataset: Dataset) -> None:
+        """Custom validation for faithfulness evaluation.
+
+        This method validates the entire chain of internal blocks by simulating
+        the data flow through each block to ensure they can all process the data correctly.
+        """
+        # Validate that required columns exist
+        required_columns = ["document", "response"]
+        missing_columns = [
+            col for col in required_columns if col not in dataset.column_names
+        ]
+        if missing_columns:
+            raise ValueError(
+                f"EvaluateFaithfulnessBlock requires columns {required_columns}, "
+                f"missing: {missing_columns}"
+            )
+
+        # Validate the entire chain of internal blocks
+        if not all(
+            [self.prompt_builder, self.llm_chat, self.text_parser, self.filter_block]
+        ):
+            raise ValueError(
+                "All internal blocks must be initialized before validation"
+            )
+
+        # Simulate data flow through the chain to validate each block
+        current_dataset = dataset
+
+        try:
+            # 1. Validate PromptBuilderBlock
+            logger.debug("Validating prompt builder block")
+            self.prompt_builder._validate_custom(current_dataset)
+
+            # Simulate prompt builder output for next validation
+            # Add the expected output column temporarily for validation
+            if "eval_faithfulness_prompt" not in current_dataset.column_names:
+                # Create a temporary dataset with the expected column for validation
+                temp_data = []
+                for sample in current_dataset:
+                    temp_sample = dict(sample)
+                    temp_sample["eval_faithfulness_prompt"] = [
+                        {"role": "user", "content": "test"}
+                    ]
+                    temp_data.append(temp_sample)
+                current_dataset = Dataset.from_list(temp_data)
+
+            # 2. Validate LLMChatBlock
+            logger.debug("Validating LLM chat block")
+            self.llm_chat._validate_custom(current_dataset)
+
+            # Simulate LLM chat output for next validation
+            if "raw_eval_faithfulness" not in current_dataset.column_names:
+                temp_data = []
+                for sample in current_dataset:
+                    temp_sample = dict(sample)
+                    temp_sample["raw_eval_faithfulness"] = (
+                        "[Start of Explanation]Test explanation[End of Explanation]\n[Start of Answer]YES[End of Answer]"
+                    )
+                    temp_data.append(temp_sample)
+                current_dataset = Dataset.from_list(temp_data)
+
+            # 3. Validate TextParserBlock
+            logger.debug("Validating text parser block")
+            self.text_parser._validate_custom(current_dataset)
+
+            # Simulate text parser output for final validation
+            if "faithfulness_judgment" not in current_dataset.column_names:
+                temp_data = []
+                for sample in current_dataset:
+                    temp_sample = dict(sample)
+                    temp_sample["faithfulness_explanation"] = "Test explanation"
+                    temp_sample["faithfulness_judgment"] = "YES"
+                    temp_data.append(temp_sample)
+                current_dataset = Dataset.from_list(temp_data)
+
+            # 4. Validate ColumnValueFilterBlock
+            logger.debug("Validating filter block")
+            self.filter_block._validate_custom(current_dataset)
+
+            logger.debug("All internal blocks validated successfully")
+
+        except Exception as e:
+            logger.error(f"Validation failed in internal blocks: {e}")
+            raise ValueError(f"Internal block validation failed: {e}") from e
+
+    def get_internal_blocks_info(self) -> Dict[str, Any]:
+        """Get information about the internal blocks.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Information about each internal block.
+        """
+        return {
+            "prompt_builder": self.prompt_builder.get_info()
+            if self.prompt_builder
+            else None,
+            "llm_chat": self.llm_chat.get_info() if self.llm_chat else None,
+            "text_parser": self.text_parser.get_info() if self.text_parser else None,
+            "filter": self.filter_block.get_info() if self.filter_block else None,
+        }
+
+    def __repr__(self) -> str:
+        """String representation of the block."""
+        return (
+            f"EvaluateFaithfulnessBlock(name='{self.block_name}', "
+            f"model='{self.model}', filter_value='{self.filter_value}')"
+        )

--- a/src/sdg_hub/blocks/evaluation/evaluate_faithfulness_block.py
+++ b/src/sdg_hub/blocks/evaluation/evaluate_faithfulness_block.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Optional, Union
 
 # Third Party
 from datasets import Dataset
-from pydantic import Field, field_validator
+from pydantic import ConfigDict, Field, field_validator
 
 # Local
 from ...logger_config import setup_logger
@@ -69,6 +69,10 @@ class EvaluateFaithfulnessBlock(BaseBlock):
         Start tags for parsing (default: ["[Start of Explanation]", "[Start of Answer]"])
     end_tags : List[str], optional
         End tags for parsing (default: ["[End of Explanation]", "[End of Answer]"])
+    parsing_pattern : Optional[str], optional
+        Regex pattern for custom parsing. If provided, takes precedence over tag-based parsing.
+    parser_cleanup_tags : Optional[List[str]], optional
+        List of tags to clean from parsed output.
 
     ### LLM Generation Parameters ###
     temperature : Optional[float], optional
@@ -85,11 +89,32 @@ class EvaluateFaithfulnessBlock(BaseBlock):
         Stop sequences.
     seed : Optional[int], optional
         Random seed for reproducible outputs.
+    response_format : Optional[Dict[str, Any]], optional
+        Response format specification (e.g., JSON mode).
+    stream : Optional[bool], optional
+        Whether to stream responses.
+    n : Optional[int], optional
+        Number of completions to generate. When n > 1, the output column will contain
+        a list of responses for each input sample.
+    logprobs : Optional[bool], optional
+        Whether to return log probabilities.
+    top_logprobs : Optional[int], optional
+        Number of top log probabilities to return.
+    user : Optional[str], optional
+        End-user identifier.
+    extra_headers : Optional[Dict[str, str]], optional
+        Additional headers to send with requests.
+    extra_body : Optional[Dict[str, Any]], optional
+        Additional parameters for the request body.
     timeout : float, optional
         Request timeout in seconds (default: 120.0).
     max_retries : int, optional
         Maximum number of retry attempts (default: 6).
+    **kwargs : Any
+        Additional provider-specific parameters.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     # Core configuration
     prompt_config_path: str = Field(
@@ -127,6 +152,12 @@ class EvaluateFaithfulnessBlock(BaseBlock):
         ["[End of Explanation]", "[End of Answer]"],
         description="End tags for parsing explanation and judgment",
     )
+    parsing_pattern: Optional[str] = Field(
+        None, description="Regex pattern for custom parsing. If provided, takes precedence over tag-based parsing"
+    )
+    parser_cleanup_tags: Optional[List[str]] = Field(
+        None, description="List of tags to clean from parsed output"
+    )
 
     # LLM generation parameters
     temperature: Optional[float] = Field(
@@ -146,8 +177,34 @@ class EvaluateFaithfulnessBlock(BaseBlock):
     seed: Optional[int] = Field(
         None, description="Random seed for reproducible outputs"
     )
+    response_format: Optional[Dict[str, Any]] = Field(
+        None, description="Response format specification (e.g., JSON mode)"
+    )
+    stream: Optional[bool] = Field(None, description="Whether to stream responses")
+    n: Optional[int] = Field(
+        None,
+        description="Number of completions to generate. When n > 1, the output column will contain a list of responses for each input sample",
+    )
+    logprobs: Optional[bool] = Field(
+        None, description="Whether to return log probabilities"
+    )
+    top_logprobs: Optional[int] = Field(
+        None, description="Number of top log probabilities to return"
+    )
+    user: Optional[str] = Field(None, description="End-user identifier")
+    extra_headers: Optional[Dict[str, str]] = Field(
+        None, description="Additional headers to send with requests"
+    )
+    extra_body: Optional[Dict[str, Any]] = Field(
+        None, description="Additional parameters for the request body"
+    )
     timeout: float = Field(120.0, description="Request timeout in seconds")
     max_retries: int = Field(6, description="Maximum number of retry attempts")
+
+    # Additional provider-specific parameters
+    llm_kwargs: Dict[str, Any] = Field(
+        default_factory=dict, description="Additional provider-specific parameters"
+    )
 
     # Internal blocks - excluded from serialization
     prompt_builder: Optional[PromptBuilderBlock] = Field(None, exclude=True)
@@ -237,17 +294,44 @@ class EvaluateFaithfulnessBlock(BaseBlock):
             llm_kwargs["stop"] = self.stop
         if self.seed is not None:
             llm_kwargs["seed"] = self.seed
+        if self.response_format is not None:
+            llm_kwargs["response_format"] = self.response_format
+        if self.stream is not None:
+            llm_kwargs["stream"] = self.stream
+        if self.n is not None:
+            llm_kwargs["n"] = self.n
+        if self.logprobs is not None:
+            llm_kwargs["logprobs"] = self.logprobs
+        if self.top_logprobs is not None:
+            llm_kwargs["top_logprobs"] = self.top_logprobs
+        if self.user is not None:
+            llm_kwargs["user"] = self.user
+        if self.extra_headers is not None:
+            llm_kwargs["extra_headers"] = self.extra_headers
+        if self.extra_body is not None:
+            llm_kwargs["extra_body"] = self.extra_body
+        
+        # Add any additional kwargs
+        llm_kwargs.update(self.llm_kwargs)
 
         self.llm_chat = LLMChatBlock(**llm_kwargs)
 
         # 3. TextParserBlock
-        self.text_parser = TextParserBlock(
-            block_name=f"{self.block_name}_text_parser",
-            input_cols=["raw_eval_faithfulness"],
-            output_cols=["faithfulness_explanation", "faithfulness_judgment"],
-            start_tags=self.start_tags,
-            end_tags=self.end_tags,
-        )
+        text_parser_kwargs = {
+            "block_name": f"{self.block_name}_text_parser",
+            "input_cols": ["raw_eval_faithfulness"],
+            "output_cols": ["faithfulness_explanation", "faithfulness_judgment"],
+            "start_tags": self.start_tags,
+            "end_tags": self.end_tags,
+        }
+        
+        # Add optional TextParserBlock parameters if specified
+        if self.parsing_pattern is not None:
+            text_parser_kwargs["parsing_pattern"] = self.parsing_pattern
+        if self.parser_cleanup_tags is not None:
+            text_parser_kwargs["parser_cleanup_tags"] = self.parser_cleanup_tags
+            
+        self.text_parser = TextParserBlock(**text_parser_kwargs)
 
         # 4. ColumnValueFilterBlock
         filter_kwargs = {

--- a/tests/blocks/evaluation/__init__.py
+++ b/tests/blocks/evaluation/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for evaluation blocks."""

--- a/tests/blocks/evaluation/test_evaluate_faithfulness_block.py
+++ b/tests/blocks/evaluation/test_evaluate_faithfulness_block.py
@@ -1,0 +1,508 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for EvaluateFaithfulnessBlock."""
+
+# Standard
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+# Third Party
+from datasets import Dataset
+import pytest
+
+# First Party
+from sdg_hub.blocks.evaluation.evaluate_faithfulness_block import (
+    EvaluateFaithfulnessBlock,
+)
+from sdg_hub.blocks.registry import BlockRegistry
+
+
+class TestEvaluateFaithfulnessBlock:
+    """Test cases for EvaluateFaithfulnessBlock."""
+
+    @pytest.fixture
+    def test_yaml_config(self):
+        """Create a temporary YAML config file for testing."""
+        yaml_content = """- role: "user"
+  content: |
+    Please evaluate the faithfulness of the following response to the given document.
+    
+    Document: {{ document }}
+    
+    Response: {{ response }}
+    
+    Please provide your evaluation in the following format:
+    
+    [Start of Explanation]
+    Provide a detailed explanation of why the response is or is not faithful to the document.
+    [End of Explanation]
+    
+    [Start of Answer]
+    YES or NO
+    [End of Answer]"""
+
+        temp_file = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)
+        temp_file.write(yaml_content)
+        temp_file.close()
+        yield temp_file.name
+        os.unlink(temp_file.name)
+
+    @pytest.fixture
+    def sample_dataset(self):
+        """Create a sample dataset for testing."""
+        return Dataset.from_dict(
+            {
+                "document": [
+                    "The sky is blue due to Rayleigh scattering.",
+                    "Water boils at 100°C at sea level.",
+                ],
+                "response": [
+                    "The sky appears blue because of light scattering.",
+                    "Water reaches boiling point at 100 degrees Celsius.",
+                ],
+            }
+        )
+
+    def test_block_registry(self):
+        """Test that EvaluateFaithfulnessBlock is properly registered."""
+        block_class = BlockRegistry.get("EvaluateFaithfulnessBlock")
+        assert block_class == EvaluateFaithfulnessBlock
+
+        # Check category
+        eval_blocks = BlockRegistry.category("evaluation")
+        assert "EvaluateFaithfulnessBlock" in eval_blocks
+
+    def test_init_with_valid_params(self, test_yaml_config):
+        """Test initialization with valid parameters."""
+        block = EvaluateFaithfulnessBlock(
+            block_name="test_faithfulness",
+            input_cols=["document", "response"],
+            output_cols=[
+                "faithfulness_explanation",
+                "faithfulness_judgment",
+                "filtered_faithfulness",
+            ],
+            prompt_config_path=test_yaml_config,
+            model="hosted_vllm/meta-llama/Llama-3.3-70B-Instruct",
+            api_base="http://localhost:8000/v1",
+            api_key="EMPTY",
+        )
+
+        assert block.block_name == "test_faithfulness"
+        assert block.input_cols == ["document", "response"]
+        assert block.output_cols == [
+            "faithfulness_explanation",
+            "faithfulness_judgment",
+            "filtered_faithfulness",
+        ]
+        assert block.model == "hosted_vllm/meta-llama/Llama-3.3-70B-Instruct"
+        assert block.filter_value == "YES"  # default
+        assert block.operation == "eq"  # default
+
+        # Check internal blocks are created
+        assert block.prompt_builder is not None
+        assert block.llm_chat is not None
+        assert block.text_parser is not None
+        assert block.filter_block is not None
+
+    def test_init_with_custom_params(self, test_yaml_config):
+        """Test initialization with custom parameters."""
+        block = EvaluateFaithfulnessBlock(
+            block_name="custom_faithfulness",
+            input_cols=["document", "response"],
+            output_cols=[
+                "faithfulness_explanation",
+                "faithfulness_judgment",
+                "filtered_faithfulness",
+            ],
+            prompt_config_path=test_yaml_config,
+            model="openai/gpt-4",
+            filter_value="FAITHFUL",
+            operation="ne",
+            convert_dtype="float",  # Use supported dtype
+            async_mode=False,
+            temperature=0.7,
+            max_tokens=1024,
+            start_tags=["<explanation>", "<judgment>"],
+            end_tags=["</explanation>", "</judgment>"],
+        )
+
+        assert block.filter_value == "FAITHFUL"
+        assert block.operation == "ne"
+        assert block.convert_dtype == "float"
+        assert block.async_mode is False
+        assert block.temperature == 0.7
+        assert block.max_tokens == 1024
+        assert block.start_tags == ["<explanation>", "<judgment>"]
+        assert block.end_tags == ["</explanation>", "</judgment>"]
+
+    def test_init_with_invalid_input_cols(self, test_yaml_config):
+        """Test initialization with invalid input columns."""
+        with pytest.raises(
+            ValueError, match="EvaluateFaithfulnessBlock expects input_cols"
+        ):
+            EvaluateFaithfulnessBlock(
+                block_name="test_faithfulness",
+                input_cols=["wrong", "columns"],
+                output_cols=[
+                    "faithfulness_explanation",
+                    "faithfulness_judgment",
+                    "filtered_faithfulness",
+                ],
+                prompt_config_path=test_yaml_config,
+                model="hosted_vllm/meta-llama/Llama-3.3-70B-Instruct",
+            )
+
+    def test_init_with_invalid_output_cols(self, test_yaml_config):
+        """Test initialization with invalid output columns."""
+        with pytest.raises(
+            ValueError, match="EvaluateFaithfulnessBlock expects output_cols"
+        ):
+            EvaluateFaithfulnessBlock(
+                block_name="test_faithfulness",
+                input_cols=["document", "response"],
+                output_cols=["wrong", "columns"],
+                prompt_config_path=test_yaml_config,
+                model="hosted_vllm/meta-llama/Llama-3.3-70B-Instruct",
+            )
+
+    def test_init_with_invalid_yaml(self):
+        """Test initialization with invalid YAML file."""
+        with pytest.raises(FileNotFoundError):
+            EvaluateFaithfulnessBlock(
+                block_name="test_faithfulness",
+                input_cols=["document", "response"],
+                output_cols=[
+                    "faithfulness_explanation",
+                    "faithfulness_judgment",
+                    "filtered_faithfulness",
+                ],
+                prompt_config_path="/nonexistent/path.yaml",
+                model="hosted_vllm/meta-llama/Llama-3.3-70B-Instruct",
+            )
+
+    def test_validate_custom_with_valid_dataset(self, test_yaml_config, sample_dataset):
+        """Test _validate_custom with valid dataset."""
+        block = EvaluateFaithfulnessBlock(
+            block_name="test_faithfulness",
+            input_cols=["document", "response"],
+            output_cols=[
+                "faithfulness_explanation",
+                "faithfulness_judgment",
+                "filtered_faithfulness",
+            ],
+            prompt_config_path=test_yaml_config,
+            model="hosted_vllm/meta-llama/Llama-3.3-70B-Instruct",
+            api_base="http://localhost:8000/v1",
+            api_key="EMPTY",
+        )
+
+        # Should not raise any exception
+        block._validate_custom(sample_dataset)
+
+    def test_validate_custom_with_missing_columns(self, test_yaml_config):
+        """Test _validate_custom with missing required columns."""
+        block = EvaluateFaithfulnessBlock(
+            block_name="test_faithfulness",
+            input_cols=["document", "response"],
+            output_cols=[
+                "faithfulness_explanation",
+                "faithfulness_judgment",
+                "filtered_faithfulness",
+            ],
+            prompt_config_path=test_yaml_config,
+            model="hosted_vllm/meta-llama/Llama-3.3-70B-Instruct",
+            api_base="http://localhost:8000/v1",
+            api_key="EMPTY",
+        )
+
+        # Dataset missing required columns
+        invalid_dataset = Dataset.from_dict({"wrong_column": ["value"]})
+
+        with pytest.raises(
+            ValueError, match="EvaluateFaithfulnessBlock requires columns"
+        ):
+            block._validate_custom(invalid_dataset)
+
+    def test_validate_custom_with_uninitialized_blocks(
+        self, test_yaml_config, sample_dataset
+    ):
+        """Test _validate_custom with uninitialized internal blocks."""
+        block = EvaluateFaithfulnessBlock(
+            block_name="test_faithfulness",
+            input_cols=["document", "response"],
+            output_cols=[
+                "faithfulness_explanation",
+                "faithfulness_judgment",
+                "filtered_faithfulness",
+            ],
+            prompt_config_path=test_yaml_config,
+            model="hosted_vllm/meta-llama/Llama-3.3-70B-Instruct",
+            api_base="http://localhost:8000/v1",
+            api_key="EMPTY",
+        )
+
+        # Manually set one of the internal blocks to None
+        block.prompt_builder = None
+
+        with pytest.raises(ValueError, match="All internal blocks must be initialized"):
+            block._validate_custom(sample_dataset)
+
+    @patch("sdg_hub.blocks.evaluation.evaluate_faithfulness_block.LLMChatBlock")
+    @patch("sdg_hub.blocks.evaluation.evaluate_faithfulness_block.PromptBuilderBlock")
+    @patch("sdg_hub.blocks.evaluation.evaluate_faithfulness_block.TextParserBlock")
+    @patch(
+        "sdg_hub.blocks.evaluation.evaluate_faithfulness_block.ColumnValueFilterBlock"
+    )
+    def test_generate_method_calls_internal_blocks(
+        self,
+        mock_filter,
+        mock_parser,
+        mock_prompt,
+        mock_llm,
+        test_yaml_config,
+        sample_dataset,
+    ):
+        """Test that generate method calls all internal blocks in correct order."""
+        # Set up mocks to return expected datasets
+        mock_prompt_instance = MagicMock()
+        mock_llm_instance = MagicMock()
+        mock_parser_instance = MagicMock()
+        mock_filter_instance = MagicMock()
+
+        mock_prompt.return_value = mock_prompt_instance
+        mock_llm.return_value = mock_llm_instance
+        mock_parser.return_value = mock_parser_instance
+        mock_filter.return_value = mock_filter_instance
+
+        # Mock the generate methods to return progressive datasets
+        step1_dataset = sample_dataset.add_column(
+            "eval_faithfulness_prompt",
+            [
+                [{"role": "user", "content": "test prompt 1"}],
+                [{"role": "user", "content": "test prompt 2"}],
+            ],
+        )
+        step2_dataset = step1_dataset.add_column(
+            "raw_eval_faithfulness",
+            [
+                "[Start of Explanation]Good explanation[End of Explanation]\n[Start of Answer]YES[End of Answer]",
+                "[Start of Explanation]Bad explanation[End of Explanation]\n[Start of Answer]NO[End of Answer]",
+            ],
+        )
+        step3_dataset = step2_dataset.add_column(
+            "faithfulness_explanation", ["Good explanation", "Bad explanation"]
+        ).add_column("faithfulness_judgment", ["YES", "NO"])
+        step4_dataset = Dataset.from_dict(
+            {
+                "document": ["The sky is blue due to Rayleigh scattering."],
+                "response": ["The sky appears blue because of light scattering."],
+                "eval_faithfulness_prompt": [
+                    [{"role": "user", "content": "test prompt 1"}]
+                ],
+                "raw_eval_faithfulness": [
+                    "[Start of Explanation]Good explanation[End of Explanation]\n[Start of Answer]YES[End of Answer]"
+                ],
+                "faithfulness_explanation": ["Good explanation"],
+                "faithfulness_judgment": ["YES"],
+            }
+        )
+
+        mock_prompt_instance.generate.return_value = step1_dataset
+        mock_llm_instance.generate.return_value = step2_dataset
+        mock_parser_instance.generate.return_value = step3_dataset
+        mock_filter_instance.generate.return_value = step4_dataset
+
+        # Create block and call generate
+        block = EvaluateFaithfulnessBlock(
+            block_name="test_faithfulness",
+            input_cols=["document", "response"],
+            output_cols=[
+                "faithfulness_explanation",
+                "faithfulness_judgment",
+                "filtered_faithfulness",
+            ],
+            prompt_config_path=test_yaml_config,
+            model="hosted_vllm/meta-llama/Llama-3.3-70B-Instruct",
+            api_base="http://localhost:8000/v1",
+            api_key="EMPTY",
+        )
+
+        result = block.generate(sample_dataset)
+
+        # Verify all internal blocks were called in order
+        mock_prompt_instance.generate.assert_called_once()
+        mock_llm_instance.generate.assert_called_once()
+        mock_parser_instance.generate.assert_called_once()
+        mock_filter_instance.generate.assert_called_once()
+
+        # Verify result contains the filtered_faithfulness column
+        assert "filtered_faithfulness" in result.column_names
+        assert all(result["filtered_faithfulness"])  # Should all be True
+
+    def test_get_internal_blocks_info(self, test_yaml_config):
+        """Test get_internal_blocks_info method."""
+        block = EvaluateFaithfulnessBlock(
+            block_name="test_faithfulness",
+            input_cols=["document", "response"],
+            output_cols=[
+                "faithfulness_explanation",
+                "faithfulness_judgment",
+                "filtered_faithfulness",
+            ],
+            prompt_config_path=test_yaml_config,
+            model="hosted_vllm/meta-llama/Llama-3.3-70B-Instruct",
+            api_base="http://localhost:8000/v1",
+            api_key="EMPTY",
+        )
+
+        info = block.get_internal_blocks_info()
+
+        assert "prompt_builder" in info
+        assert "llm_chat" in info
+        assert "text_parser" in info
+        assert "filter" in info
+
+        # Check that each internal block info is not None
+        assert info["prompt_builder"] is not None
+        assert info["llm_chat"] is not None
+        assert info["text_parser"] is not None
+        assert info["filter"] is not None
+
+    def test_get_info_method(self, test_yaml_config):
+        """Test get_info method from BaseBlock."""
+        block = EvaluateFaithfulnessBlock(
+            block_name="test_faithfulness",
+            input_cols=["document", "response"],
+            output_cols=[
+                "faithfulness_explanation",
+                "faithfulness_judgment",
+                "filtered_faithfulness",
+            ],
+            prompt_config_path=test_yaml_config,
+            model="hosted_vllm/meta-llama/Llama-3.3-70B-Instruct",
+            api_base="http://localhost:8000/v1",
+            api_key="EMPTY",
+        )
+
+        info = block.get_info()
+
+        assert info["block_name"] == "test_faithfulness"
+        assert info["block_type"] == "EvaluateFaithfulnessBlock"
+        assert info["input_cols"] == ["document", "response"]
+        assert info["output_cols"] == [
+            "faithfulness_explanation",
+            "faithfulness_judgment",
+            "filtered_faithfulness",
+        ]
+        assert info["model"] == "hosted_vllm/meta-llama/Llama-3.3-70B-Instruct"
+
+    def test_repr_method(self, test_yaml_config):
+        """Test __repr__ method."""
+        block = EvaluateFaithfulnessBlock(
+            block_name="test_faithfulness",
+            input_cols=["document", "response"],
+            output_cols=[
+                "faithfulness_explanation",
+                "faithfulness_judgment",
+                "filtered_faithfulness",
+            ],
+            prompt_config_path=test_yaml_config,
+            model="hosted_vllm/meta-llama/Llama-3.3-70B-Instruct",
+            filter_value="FAITHFUL",
+        )
+
+        repr_str = repr(block)
+        assert "EvaluateFaithfulnessBlock" in repr_str
+        assert "test_faithfulness" in repr_str
+        assert "FAITHFUL" in repr_str
+
+    def test_internal_block_configuration(self, test_yaml_config):
+        """Test that internal blocks are configured correctly."""
+        block = EvaluateFaithfulnessBlock(
+            block_name="test_faithfulness",
+            input_cols=["document", "response"],
+            output_cols=[
+                "faithfulness_explanation",
+                "faithfulness_judgment",
+                "filtered_faithfulness",
+            ],
+            prompt_config_path=test_yaml_config,
+            model="hosted_vllm/meta-llama/Llama-3.3-70B-Instruct",
+            api_base="http://localhost:8000/v1",
+            api_key="EMPTY",
+            temperature=0.8,
+            max_tokens=512,
+            filter_value="FAITHFUL",
+            operation="ne",
+        )
+
+        # Check PromptBuilderBlock configuration
+        assert block.prompt_builder.block_name == "test_faithfulness_prompt_builder"
+        assert block.prompt_builder.input_cols == ["document", "response"]
+        assert block.prompt_builder.output_cols == ["eval_faithfulness_prompt"]
+
+        # Check LLMChatBlock configuration
+        assert block.llm_chat.block_name == "test_faithfulness_llm_chat"
+        assert block.llm_chat.model == "hosted_vllm/meta-llama/Llama-3.3-70B-Instruct"
+        assert block.llm_chat.temperature == 0.8
+        assert block.llm_chat.max_tokens == 512
+
+        # Check TextParserBlock configuration
+        assert block.text_parser.block_name == "test_faithfulness_text_parser"
+        assert block.text_parser.input_cols == ["raw_eval_faithfulness"]
+        assert block.text_parser.output_cols == [
+            "faithfulness_explanation",
+            "faithfulness_judgment",
+        ]
+
+        # Check ColumnValueFilterBlock configuration
+        assert block.filter_block.block_name == "test_faithfulness_filter"
+        assert block.filter_block.input_cols == ["faithfulness_judgment"]
+        assert block.filter_block.filter_value == "FAITHFUL"
+        assert block.filter_block.operation == "ne"
+
+    def test_error_handling_in_generate(self, test_yaml_config, sample_dataset):
+        """Test error handling in generate method."""
+        block = EvaluateFaithfulnessBlock(
+            block_name="test_faithfulness",
+            input_cols=["document", "response"],
+            output_cols=[
+                "faithfulness_explanation",
+                "faithfulness_judgment",
+                "filtered_faithfulness",
+            ],
+            prompt_config_path=test_yaml_config,
+            model="hosted_vllm/meta-llama/Llama-3.3-70B-Instruct",
+            api_base="http://localhost:8000/v1",
+            api_key="EMPTY",
+        )
+
+        # Mock the prompt builder to raise an exception
+        with patch.object(
+            block.prompt_builder, "generate", side_effect=Exception("Test error")
+        ):
+            with pytest.raises(Exception, match="Test error"):
+                block.generate(sample_dataset)
+
+    def test_validation_with_empty_dataset(self, test_yaml_config):
+        """Test validation with empty dataset."""
+        block = EvaluateFaithfulnessBlock(
+            block_name="test_faithfulness",
+            input_cols=["document", "response"],
+            output_cols=[
+                "faithfulness_explanation",
+                "faithfulness_judgment",
+                "filtered_faithfulness",
+            ],
+            prompt_config_path=test_yaml_config,
+            model="hosted_vllm/meta-llama/Llama-3.3-70B-Instruct",
+            api_base="http://localhost:8000/v1",
+            api_key="EMPTY",
+        )
+
+        # Create empty dataset with required columns
+        empty_dataset = Dataset.from_dict({"document": [], "response": []})
+
+        # Should not raise exception even with empty dataset
+        block._validate_custom(empty_dataset)

--- a/tests/blocks/testdata/test_evaluate_faithfulness.yaml
+++ b/tests/blocks/testdata/test_evaluate_faithfulness.yaml
@@ -1,0 +1,17 @@
+- role: "user"
+  content: |
+    Please evaluate the faithfulness of the following response to the given document.
+    
+    Document: {{ document }}
+    
+    Response: {{ response }}
+    
+    Please provide your evaluation in the following format:
+    
+    [Start of Explanation]
+    Provide a detailed explanation of why the response is or is not faithful to the document.
+    [End of Explanation]
+    
+    [Start of Answer]
+    YES or NO
+    [End of Answer]

--- a/tests/blocks/testdata/test_evaluate_faithfulness.yaml
+++ b/tests/blocks/testdata/test_evaluate_faithfulness.yaml
@@ -14,5 +14,4 @@
     
     [Start of Answer]
     YES or NO
-    [End of Answer]
-  
+    [End of Answer] 

--- a/tests/blocks/testdata/test_evaluate_faithfulness.yaml
+++ b/tests/blocks/testdata/test_evaluate_faithfulness.yaml
@@ -15,3 +15,4 @@
     [Start of Answer]
     YES or NO
     [End of Answer]
+  


### PR DESCRIPTION
## Summary
Addresses: #270 
This PR introduces a new composite block `EvaluateFaithfulnessBlock` that combines the functionality of four separate blocks into a single evaluation block for faithfulness assessment of question-answer pairs.

**Changes made:**
- Added `EvaluateFaithfulnessBlock` composite block in `src/sdg_hub/blocks/evaluation/`
- Created comprehensive unit tests in `tests/blocks/evaluation/`
- Added test prompt configuration in `tests/blocks/testdata/`
- Updated block registry to include the new evaluation category and block

**Purpose:**
The composite block simplifies faithfulness evaluation workflows by combining:
1. `PromptBuilderBlock` - builds evaluation prompt from document and response
2. `LLMChatBlock` - generates faithfulness evaluation using LLM
3. `TextParserBlock` - parses explanation and judgment from raw output
4. `ColumnValueFilterBlock` - filters based on faithfulness judgment

This reduces configuration complexity and ensures consistent evaluation pipelines while maintaining the same functionality as the individual block chain.

## Test plan

### Parity Verification

To verify the composite block produces identical results to the 4-block chain, use this test snippet:

```python
# Test parity between 4-block chain and EvaluateFaithfulnessBlock
from datasets import Dataset
from sdg_hub.blocks.llm.prompt_builder_block import PromptBuilderBlock
from sdg_hub.blocks.llm.llm_chat_block import LLMChatBlock
from sdg_hub.blocks.llm.text_parser_block import TextParserBlock
from sdg_hub.blocks.filtering.column_value_filter import ColumnValueFilterBlock
from sdg_hub.blocks.evaluation.evaluate_faithfulness_block import EvaluateFaithfulnessBlock

# Test data
test_data = Dataset.from_list([
    {
        "document": "The sky is blue due to Rayleigh scattering.",
        "response": "The sky appears blue because of light scattering in the atmosphere."
    },
    {
        "document": "Python is a programming language.",
        "response": "Python is a type of snake that lives in tropical regions."
    }
])

# Method 1: 4-block chain (old way)
prompt_builder = PromptBuilderBlock(
    block_name="prompt_builder",
    input_cols=["document", "response"],
    output_cols=["eval_faithfulness_prompt"],
    prompt_config_path="path/to/evaluation_prompt.yaml",
    format_as_messages=True
)

llm_chat = LLMChatBlock(
    block_name="llm_chat", 
    input_cols=["eval_faithfulness_prompt"],
    output_cols=["raw_eval_faithfulness"],
    model="your_model_here",
    api_base="your_api_base_here",
    async_mode=False,
    temperature=0.0,
)

text_parser = TextParserBlock(
    block_name="text_parser",
    input_cols=["raw_eval_faithfulness"],
    output_cols=["faithfulness_explanation", "faithfulness_judgment"],
    start_tags=["[Start of Explanation]", "[Start of Answer]"],
    end_tags=["[End of Explanation]", "[End of Answer]"]
)

filter_block = ColumnValueFilterBlock(
    block_name="filter",
    input_cols=["faithfulness_judgment"],
    output_cols=[],
    filter_value="YES",
    operation="eq"
)

# Chain the blocks
result_chain = test_data
result_chain = prompt_builder.generate(result_chain)
result_chain = llm_chat.generate(result_chain)
result_chain = text_parser.generate(result_chain)
original_count_chain = len(result_chain)
result_chain = filter_block.generate(result_chain)
filtered_count_chain = len(result_chain)
result_chain = result_chain.add_column("filtered_faithfulness", [True] * filtered_count_chain)

# Method 2: Composite block (new way)  
composite_block = EvaluateFaithfulnessBlock(
    block_name="eval_faithfulness",
    input_cols=["document", "response"],
    output_cols=["faithfulness_explanation", "faithfulness_judgment", "filtered_faithfulness"],
    prompt_config_path="path/to/evaluation_prompt.yaml",
    model="your_model_here",
    api_base="your_api_base_here",
    filter_value="YES",
    operation="eq",
    async_mode=False,
    temperature=0.0,
    format_as_messages=True,
    start_tags=["[Start of Explanation]", "[Start of Answer]"],
    end_tags=["[End of Explanation]", "[End of Answer]"]
)

result_composite = composite_block.generate(test_data)

# Verify results are identical
assert result_chain.to_dict() == result_composite.to_dict()
```

### Unit Tests

Run the comprehensive test suite:
```bash
pytest tests/blocks/evaluation/test_evaluate_faithfulness_block.py -v
```

## Notes

**Open Question:** Should we consider adding a default prompt configuration for faithfulness evaluation. Currently, users must provide their own prompt configuration file, but a standardized default prompt could simplify usage for the common faithfulness evaluation scenario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **New Features**
  * Introduced the EvaluateFaithfulnessBlock for automated faithfulness evaluation of question-answer pairs using configurable prompts and large language models.

* **Tests**
  * Added comprehensive tests covering validation, error handling, and integration for EvaluateFaithfulnessBlock.
  * Included a new YAML test prompt for faithfulness evaluation.

* **Chores**
  * Improved code readability and organization in module imports and public API declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->