### PR TITLE
fix: example notebooks

### DIFF
--- a/examples/knowledge_tuning/instructlab/knowledge_generation_and_mixing.ipynb
+++ b/examples/knowledge_tuning/instructlab/knowledge_generation_and_mixing.ipynb
@@ -37,9 +37,8 @@
     "from sdg_hub.sdg import SDG\n",
     "import sys\n",
     "import os\n",
-    "sys.path.insert(0, os.path.abspath(os.path.join(os.getcwd(), '..', '..')))\n",
-    "from knowledge_utils import DocProcessor\n",
-    "import sys"
+    "sys.path.append(os.path.dirname(os.getcwd()))\n",
+    "from knowledge_utils import DocProcessor"
    ]
   },
   {
@@ -80,11 +79,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "knowledge_agentic_pipeline = \"../../../src/instructlab/sdg/flows/generation/knowledge/synth_knowledge1.5.yaml\"\n",
+    "knowledge_agentic_pipeline = \"../../../src/sdg_hub/flows/generation/knowledge/synth_knowledge1.5.yaml\"\n",
     "flow = Flow(client).get_flow_from_file(knowledge_agentic_pipeline)\n",
     "sdg = SDG(\n",
     "    flows=[flow],\n",
@@ -156,14 +155,14 @@
     "precomputed_skills_path = \"<LAB precomputed skills path>\"\n",
     "precomputed_skills = load_dataset('json', data_files=precomputed_skills_path, split='train')\n",
     "\n",
-    "generated_ds = load_dataset('json', data_files=f'{output_dir}/gen.jsonl', split='train')\n",
+    "generated_data = load_dataset('json', data_files=f'{output_dir}/gen.jsonl', split='train')\n",
     "\n",
     "# Create Pretraining Knowledge Dataset (Also known as Phase 0.7/Phase 7)\n",
-    "phase_0_7_ds = create_knowledge_pretraining_ds(generated_ds)\n",
+    "phase_0_7_ds = create_knowledge_pretraining_ds(generated_data)\n",
     "phase_0_7_ds.to_json(f'{output_dir}/phase_0_7_ds.jsonl', orient='records', lines=True)\n",
     "\n",
     "# Create Regular Knowledge Dataset (Also known as Phase 1.0/Phase 10)\n",
-    "phase_1_ds = create_knowledge_regular_ds(generated_ds)\n",
+    "phase_1_ds = create_knowledge_regular_ds(generated_data)\n",
     "\n",
     "# Mix the pre-computed skills with the regular knowledge dataset. If more than one dataset were generated simply add those in this concatenation stage.\n",
     "# If you have any generated instruction data, that can be also mixed in this stage. If you only have generated skills phase 07 generation and training can be skipped.\n",

--- a/examples/knowledge_tuning/instructlab/knowledge_generation_and_mixing.ipynb
+++ b/examples/knowledge_tuning/instructlab/knowledge_generation_and_mixing.ipynb
@@ -122,7 +122,15 @@
     "### Run SDG through python command (For large scale generation)\n",
     "\n",
     "```python\n",
-    "python /home/lab/sdg/scripts/generate.py --ds_path {output_dir}/seed_data.jsonl --bs 8 --num_workers 8 --save_path {output_dir}/gen.jsonl --flow ../src/instructlab/sdg/flows/generation/knowledge/synth_knowledge1.5.yaml --endpoint {teacher_endpoint_url} --checkpoint_dir {output_dir}/data_checkpoints --save_freq 2\n",
+    "python -m sdg_hub.flow_runner \\\n",
+    "    --ds_path {output_dir}/seed_data.jsonl \\\n",
+    "    --bs 8 \\\n",
+    "    --num_workers 8 \\\n",
+    "    --save_path {output_dir}/gen.jsonl \\\n",
+    "    --flow ../src/instructlab/sdg/flows/generation/knowledge/synth_knowledge1.5.yaml \\\n",
+    "    --endpoint {teacher_endpoint_url} \\\n",
+    "    --checkpoint_dir {output_dir}/data_checkpoints \\\n",
+    "    --save_freq 2\n",
     "```"
    ]
   },

--- a/examples/knowledge_tuning/knowledge_tuning_with_reasoning_model/prompts/generate_document_rewrite.yaml
+++ b/examples/knowledge_tuning/knowledge_tuning_with_reasoning_model/prompts/generate_document_rewrite.yaml
@@ -4,7 +4,7 @@ introduction: |
   Given below document, rewrite it using the following instructions:
   {{summary_instruction}}
 
-principles: 
+principles: |
   - Include as much of the document as possible to create a comprehensive summary
   - If there are tables include all the data of the table in the summary
 

--- a/examples/knowledge_tuning/knowledge_tuning_with_reasoning_model/prompts/generate_summary.yaml
+++ b/examples/knowledge_tuning/knowledge_tuning_with_reasoning_model/prompts/generate_summary.yaml
@@ -4,7 +4,7 @@ introduction: |
   Given below document, summarize it using the following instructions:
   {{summary_instruction}}
 
-principles: 
+principles: |
   - Include as much of the document as possible to create a comprehensive summary
   - If there are tables include all the data of the table in the summary
 

--- a/examples/knowledge_tuning/knowledge_tuning_with_reasoning_model/reasoning_sdg.ipynb
+++ b/examples/knowledge_tuning/knowledge_tuning_with_reasoning_model/reasoning_sdg.ipynb
@@ -212,7 +212,7 @@
    "source": [
     "import yaml\n",
     "# Load the exiting knowledge flow\n",
-    "with open(\"../../src/sdg_hub/flows/generation/knowledge/synth_knowledge1.5.yaml\", \"r\") as f:\n",
+    "with open(\"../../../src/sdg_hub/flows/generation/knowledge/synth_knowledge1.5.yaml\", \"r\") as f:\n",
     "    flow_config = yaml.safe_load(f)\n",
     "\n",
     "# Pretty print the flow\n",
@@ -931,7 +931,7 @@
     "  Using the instruction below, summarize the document:\n",
     "  {{summary_instruction}}\n",
     "\n",
-    "principles:\n",
+    "principles: |\n",
     "  - Include as much of the document as possible to create a comprehensive summary.\n",
     "  - If tables are present, include all table data.\n",
     "\n",


### PR DESCRIPTION
Fixed following NBs:
- knowledge_generation_with_mixing.ipynb: relative filepaths and import errors.
- reasoning_sdg:
  - prompts: principles key had list[str] as value, but we needed str. fixed that. (same for in dir).
  - relative filepaths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated file paths in notebooks to ensure correct loading of knowledge flow YAML files.
  * Improved import path handling and removed redundant imports in knowledge generation notebook.
  * Standardized variable naming for generated datasets in notebooks.

* **Style**
  * Reformatted YAML prompt files to use multiline block scalars for clearer presentation of principles.
  * Enhanced formatting of principles in YAML prompts for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->