### PR TITLE
Fix TextParserBlock to handle list inputs from LLMChatBlock when n>1

### DIFF
--- a/tests/blocks/llm/test_textparserblock.py
+++ b/tests/blocks/llm/test_textparserblock.py
@@ -1,7 +1,9 @@
+# Standard
+from unittest.mock import patch
+
 # Third Party
 from datasets import Dataset
 import pytest
-from unittest.mock import patch
 
 # First Party
 from sdg_hub.blocks.llm import TextParserBlock
@@ -210,6 +212,7 @@ def test_generate_multiple_matches_per_input(postprocessing_block_multi_column):
 
 def test_generate_missing_input_column(postprocessing_block):
     """Test that missing input column is handled by BaseBlock validation."""
+    # First Party
     from sdg_hub.utils.error_handling import MissingColumnError
 
     data = [{"other_column": "some text"}]
@@ -326,7 +329,9 @@ def test_constructor_string_output_cols():
 def test_parse_uneven_tags():
     """Test parsing with uneven start and end tags."""
     # Creating a block with more start tags than end tags should raise ValidationError
-    with pytest.raises(Exception, match="start_tags and end_tags must have the same length"):
+    with pytest.raises(
+        Exception, match="start_tags and end_tags must have the same length"
+    ):
         TextParserBlock(
             block_name="test_block",
             input_cols="raw_output",
@@ -447,7 +452,9 @@ def test_parse_with_special_characters(postprocessing_block_with_tags):
 def test_parse_mismatched_config_tags(postprocessing_block_multi_column):
     """Test parsing with mismatched numbers of start and end tags in configuration."""
     # Test case 1: More start tags than end tags should raise ValidationError
-    with pytest.raises(Exception, match="start_tags and end_tags must have the same length"):
+    with pytest.raises(
+        Exception, match="start_tags and end_tags must have the same length"
+    ):
         TextParserBlock(
             block_name="test_block",
             input_cols="raw_output",
@@ -457,7 +464,9 @@ def test_parse_mismatched_config_tags(postprocessing_block_multi_column):
         )
 
     # Test case 2: More end tags than start tags should also raise ValidationError
-    with pytest.raises(Exception, match="start_tags and end_tags must have the same length"):
+    with pytest.raises(
+        Exception, match="start_tags and end_tags must have the same length"
+    ):
         TextParserBlock(
             block_name="test_block",
             input_cols="raw_output",
@@ -697,6 +706,7 @@ def test_enhanced_logging_missing_input_column():
     """Test that BaseBlock handles missing input columns with proper validation."""
     # BaseBlock should handle missing column validation, so this should raise an error
     # during validation, not during generate()
+    # First Party
     from sdg_hub.utils.error_handling import MissingColumnError
 
     block = TextParserBlock(
@@ -758,3 +768,262 @@ def test_enhanced_logging_tag_parsing():
         assert "Tag parsing for" in debug_call
         assert "found" in debug_call
         assert "matches" in debug_call
+
+
+def test_generate_with_list_input_tag_parsing():
+    """Test generate functionality with list input from LLMChatBlock (n > 1) using tag parsing."""
+    block = TextParserBlock(
+        block_name="test_block",
+        input_cols="raw_output",
+        output_cols=["output"],
+        start_tags=["<answer>"],
+        end_tags=["</answer>"],
+    )
+
+    # Simulate output from LLMChatBlock with n=3
+    data = [
+        {
+            "raw_output": [
+                "<answer>First response</answer>",
+                "<answer>Second response</answer>",
+                "<answer>Third response</answer>",
+            ]
+        }
+    ]
+    dataset = Dataset.from_list(data)
+
+    result = block.generate(dataset)
+
+    # Should create 3 output rows, one for each response in the list
+    assert len(result) == 3
+    assert result[0]["output"] == "First response"
+    assert result[1]["output"] == "Second response"
+    assert result[2]["output"] == "Third response"
+
+
+def test_generate_with_list_input_regex_parsing():
+    """Test generate functionality with list input using regex parsing."""
+    block = TextParserBlock(
+        block_name="test_block",
+        input_cols="raw_output",
+        output_cols=["output"],
+        parsing_pattern=r"Answer: (.*?)(?:\n|$)",
+    )
+
+    # Simulate output from LLMChatBlock with n=2
+    data = [
+        {
+            "raw_output": [
+                "Question: What is 2+2?\nAnswer: Four",
+                "Question: What is 3+3?\nAnswer: Six",
+            ]
+        }
+    ]
+    dataset = Dataset.from_list(data)
+
+    result = block.generate(dataset)
+
+    # Should create 2 output rows
+    assert len(result) == 2
+    assert result[0]["output"] == "Four"
+    assert result[1]["output"] == "Six"
+
+
+def test_generate_with_list_input_multiple_matches_per_response():
+    """Test list input where each response contains multiple matches."""
+    block = TextParserBlock(
+        block_name="test_block",
+        input_cols="raw_output",
+        output_cols=["title", "content"],
+        start_tags=["<title>", "<content>"],
+        end_tags=["</title>", "</content>"],
+    )
+
+    # Each response has multiple matches
+    data = [
+        {
+            "raw_output": [
+                "<title>Title 1</title><content>Content 1</content><title>Title 2</title><content>Content 2</content>",
+                "<title>Title 3</title><content>Content 3</content>",
+            ]
+        }
+    ]
+    dataset = Dataset.from_list(data)
+
+    result = block.generate(dataset)
+
+    # First response creates 2 rows, second response creates 1 row = 3 total
+    assert len(result) == 3
+    assert result[0]["title"] == "Title 1"
+    assert result[0]["content"] == "Content 1"
+    assert result[1]["title"] == "Title 2"
+    assert result[1]["content"] == "Content 2"
+    assert result[2]["title"] == "Title 3"
+    assert result[2]["content"] == "Content 3"
+
+
+def test_generate_with_empty_list_input():
+    """Test generate functionality with empty list input."""
+    block = TextParserBlock(
+        block_name="test_block",
+        input_cols="raw_output",
+        output_cols=["output"],
+        start_tags=["<answer>"],
+        end_tags=["</answer>"],
+    )
+
+    data = [{"raw_output": []}]
+    dataset = Dataset.from_list(data)
+
+    with patch("sdg_hub.blocks.llm.text_parser_block.logger") as mock_logger:
+        result = block.generate(dataset)
+
+        # Should log warning about empty list
+        mock_logger.warning.assert_called_with(
+            "Input column 'raw_output' contains empty list"
+        )
+        assert len(result) == 0
+
+
+def test_generate_with_mixed_valid_invalid_list_items():
+    """Test list input with some valid and some invalid items."""
+    block = TextParserBlock(
+        block_name="test_block",
+        input_cols="raw_output",
+        output_cols=["output"],
+        start_tags=["<answer>"],
+        end_tags=["</answer>"],
+    )
+
+    # Test separate cases since PyArrow doesn't handle mixed types well
+    # Test with empty strings
+    data_with_empty = [
+        {
+            "raw_output": [
+                "<answer>Valid response 1</answer>",
+                "",  # Empty string
+                "<answer>Valid response 2</answer>",
+            ]
+        }
+    ]
+    dataset = Dataset.from_list(data_with_empty)
+
+    with patch("sdg_hub.blocks.llm.text_parser_block.logger") as mock_logger:
+        result = block.generate(dataset)
+
+        # Should process only the 2 valid responses
+        assert len(result) == 2
+        assert result[0]["output"] == "Valid response 1"
+        assert result[1]["output"] == "Valid response 2"
+
+        # Should log warning for empty string
+        warning_calls = [call[0][0] for call in mock_logger.warning.call_args_list]
+        assert any("List item 1" in call and "empty" in call for call in warning_calls)
+
+
+def test_generate_with_list_input_parsing_failures():
+    """Test list input where some items fail to parse."""
+    block = TextParserBlock(
+        block_name="test_block",
+        input_cols="raw_output",
+        output_cols=["output"],
+        start_tags=["<answer>"],
+        end_tags=["</answer>"],
+    )
+
+    # Some items have parseable content, others don't
+    data = [
+        {
+            "raw_output": [
+                "<answer>Parseable response 1</answer>",
+                "No tags in this response",  # Won't parse
+                "<answer>Parseable response 2</answer>",
+                "Another response without tags",  # Won't parse
+            ]
+        }
+    ]
+    dataset = Dataset.from_list(data)
+
+    with patch("sdg_hub.blocks.llm.text_parser_block.logger") as mock_logger:
+        result = block.generate(dataset)
+
+        # Should process only the 2 parseable responses
+        assert len(result) == 2
+        assert result[0]["output"] == "Parseable response 1"
+        assert result[1]["output"] == "Parseable response 2"
+
+        # Should log warnings for parsing failures
+        warning_calls = [call[0][0] for call in mock_logger.warning.call_args_list]
+        assert any(
+            "Failed to parse content from list item 1" in call for call in warning_calls
+        )
+        assert any(
+            "Failed to parse content from list item 3" in call for call in warning_calls
+        )
+
+
+def test_generate_with_list_input_all_invalid():
+    """Test list input where all items are invalid or fail parsing."""
+    block = TextParserBlock(
+        block_name="test_block",
+        input_cols="raw_output",
+        output_cols=["output"],
+        start_tags=["<answer>"],
+        end_tags=["</answer>"],
+    )
+
+    data = [{"raw_output": ["No tags here", "", None, "Also no tags"]}]
+    dataset = Dataset.from_list(data)
+
+    result = block.generate(dataset)
+
+    # Should return empty result
+    assert len(result) == 0
+
+
+def test_backwards_compatibility_string_input():
+    """Test that string inputs still work exactly as before (backwards compatibility)."""
+    block = TextParserBlock(
+        block_name="test_block",
+        input_cols="raw_output",
+        output_cols=["output"],
+        start_tags=["<answer>"],
+        end_tags=["</answer>"],
+    )
+
+    # Traditional string input (existing behavior)
+    data = [{"raw_output": "<answer>Single string response</answer>"}]
+    dataset = Dataset.from_list(data)
+
+    result = block.generate(dataset)
+
+    # Should work exactly as before
+    assert len(result) == 1
+    assert result[0]["output"] == "Single string response"
+
+
+def test_generate_with_invalid_input_type():
+    """Test handling of completely invalid input types (not string or list)."""
+    block = TextParserBlock(
+        block_name="test_block",
+        input_cols="raw_output",
+        output_cols=["output"],
+        start_tags=["<answer>"],
+        end_tags=["</answer>"],
+    )
+
+    # Dictionary input (invalid type)
+    data = [{"raw_output": {"not": "valid"}}]
+    dataset = Dataset.from_list(data)
+
+    with patch("sdg_hub.blocks.llm.text_parser_block.logger") as mock_logger:
+        result = block.generate(dataset)
+
+        # Should log warning about invalid type
+        mock_logger.warning.assert_called()
+        warning_call = mock_logger.warning.call_args[0][0]
+        assert "invalid data type" in warning_call
+        assert "Expected str or List[str]" in warning_call
+
+        # Should return empty result
+        assert len(result) == 0


### PR DESCRIPTION
## Summary

- Fixed TextParserBlock to handle list inputs from LLMChatBlock when n > 1
- Modified `_generate()` method to detect and process list inputs by iterating through each string 
- Maintains full backwards compatibility with existing string inputs
- Added comprehensive test coverage for list inputs, edge cases, and error handling

## Problem Solved

When `LLMChatBlock` is configured with `n > 1`, it returns a list of strings instead of a single string. The existing `TextParserBlock` only accepted string inputs and would return an empty list when receiving non-string data, causing downstream blocks to fail with `EmptyDatasetError`.

## Changes Made

### Core Implementation (`src/sdg_hub/blocks/llm/text_parser_block.py`)
- Modified `_generate()` method to handle both `str` and `List[str]` inputs
- For list inputs: iterate through each string, parse independently, and collect all results
- For string inputs: preserve existing behavior exactly
- Added appropriate error handling and logging for invalid list items

### Test Coverage (`tests/blocks/llm/test_textparserblock.py`)  
- Added 9 new test cases covering list input scenarios
- Tests for both tag-based and regex-based parsing with lists
- Edge cases: empty lists, mixed valid/invalid items, parsing failures
- Backwards compatibility verification for string inputs

## Test Plan

- [x] All existing tests pass (53/53) - confirms no regressions
- [x] New list input tests pass - confirms fix works correctly  
- [x] Mixed scenarios tested - validates error handling
- [x] Backwards compatibility verified - existing string behavior unchanged

Fixes #279

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of inputs by supporting both single string and list of strings, ensuring more robust parsing and better error management.
  * Enhanced warnings and output consistency for invalid or unparsable inputs.

* **Tests**
  * Added comprehensive test cases to verify correct behavior with list inputs, mixed validity items, and various edge cases.
  * Improved readability of existing tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->