### PR TITLE
Add model_override() method to Flow class for easy LLM model switching

### DIFF
--- a/src/sdg_hub/core/flow/base.py
+++ b/src/sdg_hub/core/flow/base.py
@@ -53,7 +53,7 @@ class Flow(BaseModel):
     )
 
     model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
-    
+
     # Private attributes (not serialized)
     _migrated_runtime_params: Dict[str, Dict[str, Any]] = {}
     _llm_client: Any = None  # Only used for backward compatibility with old YAMLs
@@ -153,8 +153,12 @@ class Flow(BaseModel):
         if is_old_format:
             logger.info(f"Detected old format flow, migrating: {yaml_path}")
             if client is None:
-                logger.warning("Old format YAML detected but no client provided. LLMBlocks may fail.")
-            flow_config, migrated_runtime_params = FlowMigration.migrate_to_new_format(flow_config, yaml_path)
+                logger.warning(
+                    "Old format YAML detected but no client provided. LLMBlocks may fail."
+                )
+            flow_config, migrated_runtime_params = FlowMigration.migrate_to_new_format(
+                flow_config, yaml_path
+            )
 
         # Validate YAML structure
         validator = FlowValidator()
@@ -208,12 +212,18 @@ class Flow(BaseModel):
         for i, block_config in enumerate(block_configs):
             try:
                 # Inject client for deprecated LLMBlocks if this is an old format flow
-                if is_old_format and block_config.get("block_type") == "LLMBlock" and client is not None:
+                if (
+                    is_old_format
+                    and block_config.get("block_type") == "LLMBlock"
+                    and client is not None
+                ):
                     if "block_config" not in block_config:
                         block_config["block_config"] = {}
                     block_config["block_config"]["client"] = client
-                    logger.debug(f"Injected client for deprecated LLMBlock: {block_config['block_config'].get('block_name')}")
-                
+                    logger.debug(
+                        f"Injected client for deprecated LLMBlock: {block_config['block_config'].get('block_name')}"
+                    )
+
                 block = cls._create_block_from_config(block_config, yaml_dir)
                 blocks.append(block)
             except Exception as exc:
@@ -272,7 +282,9 @@ class Flow(BaseModel):
         except KeyError as exc:
             # Get all available blocks from all categories
             all_blocks = BlockRegistry.all()
-            available_blocks = ", ".join([block for blocks in all_blocks.values() for block in blocks])
+            available_blocks = ", ".join(
+                [block for blocks in all_blocks.values() for block in blocks]
+            )
             raise FlowValidationError(
                 f"Block type '{block_type_name}' not found in registry. "
                 f"Available blocks: {available_blocks}"
@@ -380,13 +392,15 @@ class Flow(BaseModel):
             try:
                 # Check if this is a deprecated block and skip validations
                 is_deprecated_block = (
-                    hasattr(block, '__class__') and 
-                    hasattr(block.__class__, '__module__') and
-                    'deprecated_blocks' in block.__class__.__module__
+                    hasattr(block, "__class__")
+                    and hasattr(block.__class__, "__module__")
+                    and "deprecated_blocks" in block.__class__.__module__
                 )
-                
+
                 if is_deprecated_block:
-                    logger.debug(f"Skipping validations for deprecated block: {block.block_name}")
+                    logger.debug(
+                        f"Skipping validations for deprecated block: {block.block_name}"
+                    )
                     # Call generate() directly to skip validations, but keep the runtime params
                     current_dataset = block.generate(current_dataset, **block_kwargs)
                 else:
@@ -426,6 +440,173 @@ class Flow(BaseModel):
     ) -> Dict[str, Any]:
         """Prepare execution parameters for a block."""
         return runtime_params.get(block.block_name, {})
+
+    def model_override(
+        self,
+        model: Optional[str] = None,
+        api_base: Optional[str] = None,
+        api_key: Optional[str] = None,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        blocks: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Override model configurations for LLM blocks in this flow (in-place).
+
+        By default, auto-detects all LLM blocks in the flow and applies overrides to them.
+        Optionally allows targeting specific blocks only.
+
+        Parameters
+        ----------
+        model : Optional[str]
+            Model name to override (e.g., "hosted_vllm/openai/gpt-oss-120b").
+        api_base : Optional[str]
+            API base URL to override (e.g., "http://localhost:8101/v1").
+        api_key : Optional[str]
+            API key to override.
+        temperature : Optional[float]
+            Temperature parameter to override.
+        max_tokens : Optional[int]
+            Max tokens parameter to override.
+        blocks : Optional[List[str]]
+            Specific block names to target. If None, auto-detects all LLM blocks.
+        **kwargs : Any
+            Additional parameters to override for the blocks.
+
+        Examples
+        --------
+        >>> # Override model for all detected LLM blocks
+        >>> flow.model_override(
+        ...     model="hosted_vllm/openai/gpt-oss-120b",
+        ...     api_base="http://localhost:8101/v1"
+        ... )
+        >>> result = flow.generate(dataset)
+
+        >>> # Override only specific blocks
+        >>> flow.model_override(
+        ...     model="hosted_vllm/openai/gpt-oss-120b",
+        ...     api_base="http://localhost:8101/v1",
+        ...     blocks=["gen_detailed_summary", "knowledge_generation"]
+        ... )
+
+        >>> # Reset by reloading from YAML
+        >>> flow = Flow.from_yaml(flow_path)
+
+        Raises
+        ------
+        ValueError
+            If no override parameters are provided or if specified blocks don't exist.
+        """
+        # Build the override parameters dictionary
+        override_params = {}
+        if model is not None:
+            override_params["model"] = model
+        if api_base is not None:
+            override_params["api_base"] = api_base
+        if api_key is not None:
+            override_params["api_key"] = api_key
+        if temperature is not None:
+            override_params["temperature"] = temperature
+        if max_tokens is not None:
+            override_params["max_tokens"] = max_tokens
+
+        # Add any additional kwargs
+        override_params.update(kwargs)
+
+        # Validate that at least one parameter is provided
+        if not override_params:
+            raise ValueError(
+                "At least one override parameter must be provided "
+                "(model, api_base, api_key, temperature, max_tokens, or **kwargs)"
+            )
+
+        # Determine target blocks
+        if blocks is not None:
+            # Validate that specified blocks exist in the flow
+            existing_block_names = {block.block_name for block in self.blocks}
+            invalid_blocks = set(blocks) - existing_block_names
+            if invalid_blocks:
+                raise ValueError(
+                    f"Specified blocks not found in flow: {sorted(invalid_blocks)}. "
+                    f"Available blocks: {sorted(existing_block_names)}"
+                )
+            target_block_names = set(blocks)
+            logger.info(
+                f"Targeting specific blocks for override: {sorted(target_block_names)}"
+            )
+        else:
+            # Auto-detect LLM blocks
+            target_block_names = set(self._detect_llm_blocks())
+            logger.info(
+                f"Auto-detected {len(target_block_names)} LLM blocks for override: {sorted(target_block_names)}"
+            )
+
+        # Apply overrides to target blocks
+        modified_count = 0
+        for block in self.blocks:
+            if block.block_name in target_block_names:
+                for param_name, param_value in override_params.items():
+                    if hasattr(block, param_name):
+                        old_value = getattr(block, param_name)
+                        setattr(block, param_name, param_value)
+                        logger.debug(
+                            f"Block '{block.block_name}': {param_name} "
+                            f"'{old_value}' -> '{param_value}'"
+                        )
+                    else:
+                        logger.warning(
+                            f"Block '{block.block_name}' ({block.__class__.__name__}) "
+                            f"does not have attribute '{param_name}' - skipping"
+                        )
+                modified_count += 1
+
+        if modified_count > 0:
+            logger.info(
+                f"Successfully overrode {len(override_params)} parameters "
+                f"for {modified_count} blocks: {list(override_params.keys())}"
+            )
+        else:
+            logger.warning(
+                "No blocks were modified - check block names or LLM block detection"
+            )
+
+    def _detect_llm_blocks(self) -> List[str]:
+        """Detect LLM blocks in the flow by checking for model-related attributes.
+
+        Returns
+        -------
+        List[str]
+            List of block names that have LLM-related attributes (model, api_base, or api_key).
+        """
+        llm_blocks = []
+
+        for block in self.blocks:
+            block_type = block.__class__.__name__
+            block_name = block.block_name
+
+            # Check by attributes (has model-related configuration)
+            has_model_attr = (
+                hasattr(block, "model") and getattr(block, "model", None) is not None
+            )
+            has_api_base_attr = (
+                hasattr(block, "api_base")
+                and getattr(block, "api_base", None) is not None
+            )
+            has_api_key_attr = (
+                hasattr(block, "api_key") and getattr(block, "api_key", None) is not None
+            )
+
+            # A block is considered an LLM block if it has any LLM-related attributes
+            is_llm_block = has_model_attr or has_api_base_attr or has_api_key_attr
+
+            if is_llm_block:
+                llm_blocks.append(block_name)
+                logger.debug(
+                    f"Detected LLM block '{block_name}' ({block_type}): "
+                    f"model={has_model_attr}, api_base={has_api_base_attr}, api_key={has_api_key_attr}"
+                )
+
+        return llm_blocks
 
     def validate_dataset(self, dataset: Dataset) -> List[str]:
         """Validate dataset against flow requirements."""
@@ -527,13 +708,15 @@ class Flow(BaseModel):
 
                 # Check if this is a deprecated block and skip validations
                 is_deprecated_block = (
-                    hasattr(block, '__class__') and 
-                    hasattr(block.__class__, '__module__') and
-                    'deprecated_blocks' in block.__class__.__module__
+                    hasattr(block, "__class__")
+                    and hasattr(block.__class__, "__module__")
+                    and "deprecated_blocks" in block.__class__.__module__
                 )
-                
+
                 if is_deprecated_block:
-                    logger.debug(f"Dry run: Skipping validations for deprecated block: {block.block_name}")
+                    logger.debug(
+                        f"Dry run: Skipping validations for deprecated block: {block.block_name}"
+                    )
                     # Call generate() directly to skip validations, but keep the runtime params
                     current_dataset = block.generate(current_dataset, **block_kwargs)
                 else:

--- a/tests/flow/test_base.py
+++ b/tests/flow/test_base.py
@@ -497,3 +497,271 @@ class TestFlow:
         block = self.create_mock_block("test_block")
         flow = Flow(blocks=[block], metadata=self.test_metadata)
         assert len(flow) == 1
+
+    def create_mock_llm_block(self, name="llm_block", model="test-model", api_base="http://localhost:8000/v1", api_key="EMPTY"):
+        """Create a mock LLM block with model attributes."""
+        from tests.flow.conftest import MockBlock
+        block = MockBlock(
+            block_name=name,
+            input_cols=["input"],
+            output_cols=["output"]
+        )
+        # Add LLM-related attributes
+        block.model = model
+        block.api_base = api_base
+        block.api_key = api_key
+        block.temperature = 0.0
+        block.max_tokens = 1024
+        return block
+
+    def test_detect_llm_blocks_by_model_attribute(self):
+        """Test detecting LLM blocks by model attribute."""
+        regular_block = self.create_mock_block("regular_block")
+        llm_block = self.create_mock_llm_block("llm_block", model="test-model")
+        
+        flow = Flow(blocks=[regular_block, llm_block], metadata=self.test_metadata)
+        
+        detected_blocks = flow._detect_llm_blocks()
+        
+        assert len(detected_blocks) == 1
+        assert "llm_block" in detected_blocks
+        assert "regular_block" not in detected_blocks
+
+    def test_detect_llm_blocks_by_api_base_attribute(self):
+        """Test detecting LLM blocks by api_base attribute."""
+        regular_block = self.create_mock_block("regular_block")
+        llm_block = self.create_mock_llm_block("llm_block", model=None)
+        llm_block.model = None  # Remove model but keep api_base
+        
+        flow = Flow(blocks=[regular_block, llm_block], metadata=self.test_metadata)
+        
+        detected_blocks = flow._detect_llm_blocks()
+        
+        assert len(detected_blocks) == 1
+        assert "llm_block" in detected_blocks
+
+    def test_detect_llm_blocks_by_api_key_attribute(self):
+        """Test detecting LLM blocks by api_key attribute."""
+        regular_block = self.create_mock_block("regular_block")
+        llm_block = self.create_mock_llm_block("llm_block", model=None, api_base=None)
+        llm_block.model = None
+        llm_block.api_base = None
+        # Only api_key remains
+        
+        flow = Flow(blocks=[regular_block, llm_block], metadata=self.test_metadata)
+        
+        detected_blocks = flow._detect_llm_blocks()
+        
+        assert len(detected_blocks) == 1
+        assert "llm_block" in detected_blocks
+
+    def test_detect_llm_blocks_none_found(self):
+        """Test detecting LLM blocks when none exist."""
+        regular_block1 = self.create_mock_block("regular_block1")
+        regular_block2 = self.create_mock_block("regular_block2")
+        
+        flow = Flow(blocks=[regular_block1, regular_block2], metadata=self.test_metadata)
+        
+        detected_blocks = flow._detect_llm_blocks()
+        
+        assert len(detected_blocks) == 0
+
+    def test_detect_llm_blocks_multiple(self):
+        """Test detecting multiple LLM blocks."""
+        regular_block = self.create_mock_block("regular_block")
+        llm_block1 = self.create_mock_llm_block("llm_block1", model="model1")
+        llm_block2 = self.create_mock_llm_block("llm_block2", model="model2")
+        llm_block3 = self.create_mock_llm_block("llm_block3", model=None, api_base="http://localhost:8001/v1")
+        llm_block3.model = None  # Only has api_base
+        
+        flow = Flow(blocks=[regular_block, llm_block1, llm_block2, llm_block3], metadata=self.test_metadata)
+        
+        detected_blocks = flow._detect_llm_blocks()
+        
+        assert len(detected_blocks) == 3
+        assert "llm_block1" in detected_blocks
+        assert "llm_block2" in detected_blocks
+        assert "llm_block3" in detected_blocks
+        assert "regular_block" not in detected_blocks
+
+    def test_model_override_all_llm_blocks(self):
+        """Test model override with auto-detection of all LLM blocks."""
+        regular_block = self.create_mock_block("regular_block")
+        llm_block1 = self.create_mock_llm_block("llm_block1", model="old-model1")
+        llm_block2 = self.create_mock_llm_block("llm_block2", model="old-model2")
+        
+        flow = Flow(blocks=[regular_block, llm_block1, llm_block2], metadata=self.test_metadata)
+        
+        # Override model for all LLM blocks
+        flow.model_override(
+            model="new-model",
+            api_base="http://localhost:8101/v1",
+            api_key="NEW_KEY",
+            temperature=0.7,
+            max_tokens=2048
+        )
+        
+        # Check that LLM blocks were modified
+        assert flow.blocks[1].model == "new-model"  # llm_block1
+        assert flow.blocks[1].api_base == "http://localhost:8101/v1"
+        assert flow.blocks[1].api_key == "NEW_KEY"
+        assert flow.blocks[1].temperature == 0.7
+        assert flow.blocks[1].max_tokens == 2048
+        
+        assert flow.blocks[2].model == "new-model"  # llm_block2
+        assert flow.blocks[2].api_base == "http://localhost:8101/v1"
+        
+        # Check that regular block was not modified (doesn't have these attributes)
+        assert not hasattr(flow.blocks[0], "model")
+
+    def test_model_override_specific_blocks(self):
+        """Test model override with specific block targeting."""
+        llm_block1 = self.create_mock_llm_block("llm_block1", model="old-model1")
+        llm_block2 = self.create_mock_llm_block("llm_block2", model="old-model2")
+        llm_block3 = self.create_mock_llm_block("llm_block3", model="old-model3")
+        
+        flow = Flow(blocks=[llm_block1, llm_block2, llm_block3], metadata=self.test_metadata)
+        
+        # Override only specific blocks
+        flow.model_override(
+            model="new-model",
+            api_base="http://localhost:8101/v1",
+            blocks=["llm_block1", "llm_block3"]
+        )
+        
+        # Check that only specified blocks were modified
+        assert flow.blocks[0].model == "new-model"  # llm_block1
+        assert flow.blocks[0].api_base == "http://localhost:8101/v1"
+        
+        assert flow.blocks[1].model == "old-model2"  # llm_block2 unchanged
+        assert flow.blocks[1].api_base == "http://localhost:8000/v1"  # unchanged
+        
+        assert flow.blocks[2].model == "new-model"  # llm_block3
+        assert flow.blocks[2].api_base == "http://localhost:8101/v1"
+
+    def test_model_override_partial_parameters(self):
+        """Test model override with only some parameters."""
+        llm_block = self.create_mock_llm_block("llm_block", 
+                                               model="old-model", 
+                                               api_base="http://localhost:8000/v1",
+                                               api_key="OLD_KEY")
+        llm_block.temperature = 0.0
+        llm_block.max_tokens = 1024
+        
+        flow = Flow(blocks=[llm_block], metadata=self.test_metadata)
+        
+        # Override only model and temperature
+        flow.model_override(
+            model="new-model",
+            temperature=0.8
+        )
+        
+        # Check that only specified parameters were changed
+        assert flow.blocks[0].model == "new-model"
+        assert flow.blocks[0].temperature == 0.8
+        
+        # Other parameters should remain unchanged
+        assert flow.blocks[0].api_base == "http://localhost:8000/v1"
+        assert flow.blocks[0].api_key == "OLD_KEY"
+        assert flow.blocks[0].max_tokens == 1024
+
+    def test_model_override_with_kwargs(self):
+        """Test model override with additional kwargs."""
+        llm_block = self.create_mock_llm_block("llm_block")
+        llm_block.top_p = 1.0
+        llm_block.frequency_penalty = 0.0
+        
+        flow = Flow(blocks=[llm_block], metadata=self.test_metadata)
+        
+        # Override with additional parameters via kwargs
+        flow.model_override(
+            model="new-model",
+            top_p=0.9,
+            frequency_penalty=0.1
+        )
+        
+        assert flow.blocks[0].model == "new-model"
+        assert flow.blocks[0].top_p == 0.9
+        assert flow.blocks[0].frequency_penalty == 0.1
+
+    def test_model_override_no_parameters(self):
+        """Test model override with no parameters raises error."""
+        llm_block = self.create_mock_llm_block("llm_block")
+        flow = Flow(blocks=[llm_block], metadata=self.test_metadata)
+        
+        with pytest.raises(ValueError) as exc_info:
+            flow.model_override()
+        
+        assert "At least one override parameter must be provided" in str(exc_info.value)
+
+    def test_model_override_invalid_block_names(self):
+        """Test model override with invalid block names raises error."""
+        llm_block = self.create_mock_llm_block("llm_block")
+        flow = Flow(blocks=[llm_block], metadata=self.test_metadata)
+        
+        with pytest.raises(ValueError) as exc_info:
+            flow.model_override(
+                model="new-model",
+                blocks=["nonexistent_block", "another_missing_block"]
+            )
+        
+        assert "Specified blocks not found in flow" in str(exc_info.value)
+        assert "nonexistent_block" in str(exc_info.value)
+        assert "another_missing_block" in str(exc_info.value)
+
+    def test_model_override_no_llm_blocks_detected(self):
+        """Test model override when no LLM blocks are detected."""
+        regular_block1 = self.create_mock_block("regular_block1")
+        regular_block2 = self.create_mock_block("regular_block2")
+        
+        flow = Flow(blocks=[regular_block1, regular_block2], metadata=self.test_metadata)
+        
+        # Should not raise error but log warning
+        flow.model_override(model="new-model")
+        
+        # Blocks should remain unchanged
+        assert not hasattr(flow.blocks[0], "model")
+        assert not hasattr(flow.blocks[1], "model")
+
+    def test_model_override_missing_attributes_warning(self):
+        """Test model override logs warning for missing attributes."""
+        # Create a block that has model but not other attributes
+        llm_block = self.create_mock_llm_block("llm_block")
+        delattr(llm_block, "api_base")  # Remove api_base attribute
+        
+        flow = Flow(blocks=[llm_block], metadata=self.test_metadata)
+        
+        # This should work for model but log warning for api_base
+        flow.model_override(
+            model="new-model",
+            api_base="http://localhost:8101/v1"
+        )
+        
+        # Model should be changed
+        assert flow.blocks[0].model == "new-model"
+        # api_base should not be set since attribute doesn't exist
+
+    def test_model_override_preserves_unspecified_attributes(self):
+        """Test that model override preserves attributes not specified."""
+        llm_block = self.create_mock_llm_block("llm_block",
+                                               model="original-model",
+                                               api_base="http://localhost:8000/v1",
+                                               api_key="ORIGINAL_KEY")
+        llm_block.temperature = 0.5
+        llm_block.max_tokens = 1024
+        llm_block.custom_param = "custom_value"
+        
+        flow = Flow(blocks=[llm_block], metadata=self.test_metadata)
+        
+        # Override only model
+        flow.model_override(model="new-model")
+        
+        # Only model should change
+        assert flow.blocks[0].model == "new-model"
+        
+        # Everything else should remain the same
+        assert flow.blocks[0].api_base == "http://localhost:8000/v1"
+        assert flow.blocks[0].api_key == "ORIGINAL_KEY"
+        assert flow.blocks[0].temperature == 0.5
+        assert flow.blocks[0].max_tokens == 1024
+        assert flow.blocks[0].custom_param == "custom_value"


### PR DESCRIPTION
## Summary
This PR adds a new `model_override()` method to the Flow class that allows users to easily override model configurations for LLM blocks in a flow, addressing the need for easy model switching without modifying YAML files.

**Key features:**
- Auto-detects LLM blocks by checking for model-related attributes (model, api_base, api_key)
- Supports overriding all detected LLM blocks or targeting specific blocks
- In-place modification with comprehensive parameter support
- Robust error handling and comprehensive logging

## Changes Made
- ✅ Added `model_override()` method to Flow class (`src/sdg_hub/core/flow/base.py`)
- ✅ Added `_detect_llm_blocks()` helper method for attribute-based LLM block detection
- ✅ Added comprehensive test coverage with 14 new tests (`tests/flow/test_base.py`)
- ✅ Improved code formatting consistency

## Usage Example
```python
from sdg_hub.core.flow import FlowRegistry, Flow

# Load your flow
flow_name = "Advanced Document Grounded Question-Answer Generation Flow for Knowledge Tuning"
flow_path = FlowRegistry.get_flow_path(flow_name)
flow = Flow.from_yaml(flow_path)

# Override model for all LLM blocks
flow.model_override(
    model="hosted_vllm/openai/gpt-oss-120b",
    api_base="http://localhost:8101/v1",
    api_key="EMPTY"
)

# Run with your new model
result = flow.generate(dataset)

# Reset by reloading from YAML if needed
flow = Flow.from_yaml(flow_path)
```

## Test Coverage
Added 14 comprehensive tests covering:
- ✅ LLM block detection by different attributes (model, api_base, api_key)
- ✅ Auto-detection vs. specific block targeting
- ✅ Partial parameter overrides
- ✅ Error cases (no parameters, invalid block names)
- ✅ Edge cases (no LLM blocks, missing attributes)
- ✅ Preservation of unchanged attributes

## Test Results
```bash
$ pytest tests/flow/test_base.py -k "test_detect_llm_blocks or test_model_override" -v
========================= 14 passed, 30 deselected, 1 warning in 0.02s =========================

$ pytest tests/flow/test_base.py -v
========================= 44 passed, 1 warning in 0.07s =========================
```

## Breaking Changes
None - this is a pure addition to the existing API.

## Documentation
The method includes comprehensive docstrings with examples and parameter descriptions.

🤖 Generated with [Claude Code](https://claude.ai/code)