### PR TITLE
New constraints to litellm versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "datasets>=2.18.0,<4.0.0",
     "httpx>=0.25.0,<1.0.0",
     "jinja2",
-    "litellm>=1.73.0, <1.75.0",
+    "litellm>=1.73.0,<1.75.0",
     "openai>=1.13.3,<2.0.0",
     "rich",
     "pydantic>=2.0.0,<3.0.0",         # cap before v3; adjust the lower bound to the minimum v2.x you’ve tested

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "datasets>=2.18.0,<4.0.0",
     "httpx>=0.25.0,<1.0.0",
     "jinja2",
-    "litellm>=1.61.15",
+    "litellm>=1.73.0, <1.75.0",
     "openai>=1.13.3,<2.0.0",
     "rich",
     "pydantic>=2.0.0,<3.0.0",         # cap before v3; adjust the lower bound to the minimum v2.x you’ve tested


### PR DESCRIPTION
 ## Summary

Constrained litellm version to `>=1.73.0, <1.75.0` to prevent import errors
  related to missing dependencies `backoff`

## Problem

  Users were encountering errors when litellm tried to import missing optional
  dependencies (backoff, tenacity) that are required for proxy functionality but
   not included in the base litellm installation.

 ## Solution

  Added upper bound constraint to litellm version to ensure compatibility and
  avoid dependency conflicts that cause runtime import errors until `litellm` stabilizes 1.75.z releases

 ## Test plan

  - Verify litellm imports successfully without backoff/tenacity errors
  - Run existing tests to ensure no regressions
  - Test core LLM functionality still works as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the version range for the "litellm" dependency to ensure compatibility with versions 1.73.0 up to, but not including, 1.75.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->