### PR TITLE
Add optional log_dir parameter to Flow.generate() for dual logging

### DIFF
--- a/src/sdg_hub/core/flow/base.py
+++ b/src/sdg_hub/core/flow/base.py
@@ -405,15 +405,18 @@ class Flow(BaseModel):
         # Set up file logging if log_dir is provided
         if log_dir is not None:
             from datetime import datetime
+
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             flow_name = self.metadata.name.replace(" ", "_").lower()
             log_filename = f"{flow_name}_{timestamp}.log"
-            
+
             # Clear existing handlers and reinitialize the global logger with file logging
             global logger
             logger.handlers.clear()  # Clear existing handlers so setup_logger can add new ones
             logger = setup_logger(__name__, log_dir=log_dir, log_filename=log_filename)
-            logger.info(f"Flow logging enabled - logs will be saved to: {log_dir}/{log_filename}")
+            logger.info(
+                f"Flow logging enabled - logs will be saved to: {log_dir}/{log_filename}"
+            )
 
         # Validate preconditions
         if not self.blocks:

--- a/src/sdg_hub/core/flow/base.py
+++ b/src/sdg_hub/core/flow/base.py
@@ -357,6 +357,7 @@ class Flow(BaseModel):
         runtime_params: Optional[dict[str, dict[str, Any]]] = None,
         checkpoint_dir: Optional[str] = None,
         save_freq: Optional[int] = None,
+        log_dir: Optional[str] = None,
     ) -> Dataset:
         """Execute the flow blocks in sequence to generate data.
 
@@ -378,6 +379,10 @@ class Flow(BaseModel):
         save_freq : Optional[int], optional
             Number of completed samples after which to save a checkpoint.
             If None, only saves final results when checkpointing is enabled.
+        log_dir : Optional[str], optional
+            Directory to save execution logs. If provided, logs will be written to both
+            console and a log file in this directory. Maintains backward compatibility
+            when None.
 
         Returns
         -------
@@ -396,6 +401,19 @@ class Flow(BaseModel):
             raise FlowValidationError(
                 f"save_freq must be greater than 0, got {save_freq}"
             )
+
+        # Set up file logging if log_dir is provided
+        if log_dir is not None:
+            from datetime import datetime
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            flow_name = self.metadata.name.replace(" ", "_").lower()
+            log_filename = f"{flow_name}_{timestamp}.log"
+            
+            # Clear existing handlers and reinitialize the global logger with file logging
+            global logger
+            logger.handlers.clear()  # Clear existing handlers so setup_logger can add new ones
+            logger = setup_logger(__name__, log_dir=log_dir, log_filename=log_filename)
+            logger.info(f"Flow logging enabled - logs will be saved to: {log_dir}/{log_filename}")
 
         # Validate preconditions
         if not self.blocks:

--- a/src/sdg_hub/core/utils/logger_config.py
+++ b/src/sdg_hub/core/utils/logger_config.py
@@ -7,14 +7,48 @@ import os
 from rich.logging import RichHandler
 
 
-def setup_logger(name):
-    # Set up the logger
-    log_level = os.getenv("LOG_LEVEL", "INFO")
-    logging.basicConfig(
-        level=log_level,
-        format="%(message)s",
-        datefmt="[%X]",
-        handlers=[RichHandler()],
-    )
+def setup_logger(name, log_dir=None, log_filename="sdg_hub.log"):
+    """
+    Set up a logger with optional file logging.
+
+    Parameters
+    ----------
+    name : str
+        Logger name.
+    log_dir : str, optional
+        Directory to save log files. If None, logs are not saved to file.
+    log_filename : str, optional
+        Name of the log file (default: "sdg_hub.log").
+
+    Returns
+    -------
+    logging.Logger
+        Configured logger.
+    """
+    log_level = os.getenv("LOG_LEVEL", "INFO").upper()
     logger = logging.getLogger(name)
+    logger.setLevel(log_level)
+
+    # Prevent duplicate handlers if setup_logger is called multiple times
+    if not logger.handlers:
+        # Rich console handler
+        rich_handler = RichHandler()
+        rich_handler.setLevel(log_level)
+        formatter = logging.Formatter("%(message)s", datefmt="[%X]")
+        rich_handler.setFormatter(formatter)
+        logger.addHandler(rich_handler)
+
+        # Optional file handler
+        if log_dir is not None:
+            os.makedirs(log_dir, exist_ok=True)
+            file_path = os.path.join(log_dir, log_filename)
+            file_handler = logging.FileHandler(file_path, encoding="utf-8")
+            file_handler.setLevel(log_level)
+            file_formatter = logging.Formatter(
+                "%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+                datefmt="[%Y-%m-%d %H:%M:%S]",
+            )
+            file_handler.setFormatter(file_formatter)
+            logger.addHandler(file_handler)
+
     return logger

--- a/tests/flow/test_base.py
+++ b/tests/flow/test_base.py
@@ -1142,7 +1142,7 @@ class TestFlow:
 
         # Check log file content
         log_file = log_files[0]
-        with open(log_file, 'r', encoding='utf-8') as f:
+        with open(log_file, "r", encoding="utf-8") as f:
             log_content = f.read()
 
         # Should contain flow execution logs
@@ -1195,10 +1195,10 @@ class TestFlow:
         checkpoint_dir = Path(self.temp_dir) / "checkpoints_with_logs"
 
         result = flow.generate(
-            dataset, 
-            log_dir=str(log_dir), 
+            dataset,
+            log_dir=str(log_dir),
             checkpoint_dir=str(checkpoint_dir),
-            save_freq=1
+            save_freq=1,
         )
 
         assert len(result) == 2

--- a/tests/flow/test_base.py
+++ b/tests/flow/test_base.py
@@ -1121,3 +1121,96 @@ class TestFlow:
         with open(checkpoint_files[0], "r") as f:
             checkpoint_data = json.loads(f.readline())
             assert "final" in checkpoint_data
+
+    def test_generate_with_log_dir(self):
+        """Test generation with log_dir parameter for dual logging."""
+        block = self.create_mock_block("test_block", output_cols=["output"])
+        flow = Flow(blocks=[block], metadata=self.test_metadata)
+        dataset = Dataset.from_dict({"input": ["test1", "test2"]})
+
+        log_dir = Path(self.temp_dir) / "test_logs"
+
+        result = flow.generate(dataset, log_dir=str(log_dir))
+
+        assert len(result) == 2
+        assert "output" in result.column_names
+
+        # Should have created log directory and log file
+        assert log_dir.exists()
+        log_files = list(log_dir.glob("*.log"))
+        assert len(log_files) == 1
+
+        # Check log file content
+        log_file = log_files[0]
+        with open(log_file, 'r', encoding='utf-8') as f:
+            log_content = f.read()
+
+        # Should contain flow execution logs
+        assert "Starting flow 'Test Flow'" in log_content
+        assert "completed successfully" in log_content
+        assert "test_block" in log_content
+
+        # Log filename should include flow name and timestamp
+        assert "test_flow_" in log_file.name
+        assert log_file.name.endswith(".log")
+
+    def test_generate_without_log_dir(self):
+        """Test generation without log_dir parameter (original behavior)."""
+        block = self.create_mock_block("test_block", output_cols=["output"])
+        flow = Flow(blocks=[block], metadata=self.test_metadata)
+        dataset = Dataset.from_dict({"input": ["test1", "test2"]})
+
+        # Should work without log_dir (backward compatibility)
+        result = flow.generate(dataset)
+
+        assert len(result) == 2
+        assert "output" in result.column_names
+
+    def test_generate_with_log_dir_creates_directory(self):
+        """Test that log_dir is created if it doesn't exist."""
+        block = self.create_mock_block("test_block", output_cols=["output"])
+        flow = Flow(blocks=[block], metadata=self.test_metadata)
+        dataset = Dataset.from_dict({"input": ["test1"]})
+
+        # Use a nested path that doesn't exist
+        log_dir = Path(self.temp_dir) / "nested" / "log" / "directory"
+        assert not log_dir.exists()
+
+        result = flow.generate(dataset, log_dir=str(log_dir))
+
+        assert len(result) == 1
+        # Directory should be created
+        assert log_dir.exists()
+        # Log file should be created
+        log_files = list(log_dir.glob("*.log"))
+        assert len(log_files) == 1
+
+    def test_generate_with_log_dir_and_checkpointing(self):
+        """Test generation with both log_dir and checkpointing."""
+        block = self.create_mock_block("test_block", output_cols=["output"])
+        flow = Flow(blocks=[block], metadata=self.test_metadata)
+        dataset = Dataset.from_dict({"input": ["test1", "test2"]})
+
+        log_dir = Path(self.temp_dir) / "logs_with_checkpoints"
+        checkpoint_dir = Path(self.temp_dir) / "checkpoints_with_logs"
+
+        result = flow.generate(
+            dataset, 
+            log_dir=str(log_dir), 
+            checkpoint_dir=str(checkpoint_dir),
+            save_freq=1
+        )
+
+        assert len(result) == 2
+
+        # Both log and checkpoint directories should exist
+        assert log_dir.exists()
+        assert checkpoint_dir.exists()
+
+        # Should have log files
+        log_files = list(log_dir.glob("*.log"))
+        assert len(log_files) == 1
+
+        # Should have checkpoint files
+        checkpoint_files = list(checkpoint_dir.glob("checkpoint_*.jsonl"))
+        assert len(checkpoint_files) == 2


### PR DESCRIPTION
This PR(addresses #313) adds an optional log_dir parameter to the Flow.generate() method to enable saving execution logs to a specified directory while maintaining console output. This enhancement improves debugging capabilities and enables log persistence for analysis and monitoring.

### Changes

1. Added log_dir: Optional[str] = None parameter to Flow.generate() method
2. Leverages existing setup_logger() functionality from logger_config.py for dual logging
3. Maintains full backward compatibility - existing code works unchanged
4. Generates timestamped log files to prevent overwrites

### Benefits

1. Debugging: Review execution logs after completion
2. Monitoring: Track flow performance and issues over time
3. Documentation: Preserve execution history for auditing
4. Analysis: Enable log analysis tools and metrics collection

### Usage
The log_dir parameter works seamlessly with existing Flow usage:

```python
# Load your flow
flow_registry = FlowRegistry()
flow_registry.register_search_path("examples/knowledge_tuning")
flow_registry.discover_flows()

flow_path = flow_registry.get_flow_path("flow_id_or_name")
flow = Flow.from_yaml(flow_path)

# Load your dataset
dataset = Dataset.from_json("dataset.jsonl")

# Configure model
flow.set_model_config(
    model="openai/gpt-4o-mini",
    api_key=os.getenv("OPENAI_API_KEY"),
)

# Generate with dual logging (console + file)
data = flow.generate(
    dataset, 
    checkpoint_dir="./checkpoint_dir", 
    log_dir="./log_dir"  # New parameter - logs saved to timestamped files, remove the parameter to log only to console
)


```

### Log File Output

1. Location: ./log_dir/
2. Filename format: flow_name_YYYYMMDD_HHMMSS.log
3. Content: Same logs as console output, formatted for easy analysis
4. Dual output: Logs appear in both console and file simultaneously

This implementation provides the requested dual logging functionality with minimal code changes and maximum compatibility.