### PR TITLE
Make BlockRegistry.get() private and fix documentation

### DIFF
--- a/docs/blocks/llm-blocks.md
+++ b/docs/blocks/llm-blocks.md
@@ -34,11 +34,8 @@ The unified chat block that replaces provider-specific implementations with a si
 ### Basic Usage
 
 ```python
-from sdg_hub.core.blocks import BlockRegistry
+from sdg_hub.core.blocks import LLMChatBlock
 from datasets import Dataset
-
-# Get the LLM chat block
-LLMChatBlock = BlockRegistry.get_block("LLMChatBlock")
 
 # Configure for OpenAI
 chat_block = LLMChatBlock(

--- a/docs/blocks/overview.md
+++ b/docs/blocks/overview.md
@@ -30,14 +30,15 @@ All blocks inherit from `BaseBlock`, which provides:
 
 ### Standard Configuration
 ```python
-from sdg_hub.core.blocks import BlockRegistry
+# Import the specific block you need
+from sdg_hub.core.blocks import LLMChatBlock
 
 # Every block has these standard fields
-MyBlock = BlockRegistry.get_block("SomeBlockType")
-block = MyBlock(
+block = LLMChatBlock(
     block_name="my_unique_block",     # Required: unique identifier
-    input_cols=["column1", "column2"], # Columns this block needs
-    output_cols=["new_column"],       # Columns this block creates
+    input_cols=["input_text"],        # Column this block needs
+    output_cols=["response"],         # Column this block creates
+    model="openai/gpt-4o",            # Required: provider/model format
     # ... block-specific configuration
 )
 ```
@@ -86,13 +87,13 @@ print(f"Found {len(available_blocks)} blocks")
 
 ### 2. Block Instantiation
 ```python
-# Get a block class by name
-ChatBlock = BlockRegistry.get_block("LLMChatBlock")
+# Import the specific block you need
+from sdg_hub.core.blocks import LLMChatBlock
 
 # Create an instance with configuration
-chat_block = ChatBlock(
+chat_block = LLMChatBlock(
     block_name="question_answerer",
-    llm_config={"model": "gpt-4o"},
+    model="openai/gpt-4o",
     input_cols=["question"],
     output_cols=["answer"],
     prompt_template="Answer this question: {question}"

--- a/docs/development.md
+++ b/docs/development.md
@@ -123,15 +123,16 @@ Create comprehensive tests following this pattern:
 
 import pytest
 from datasets import Dataset
-from sdg_hub.core.blocks import BlockRegistry
 from sdg_hub.core.utils.error_handling import MissingColumnError
+# Import your custom block directly
+from .my_new_block import MyNewBlock
 
 class TestMyNewBlock:
     """Test suite for MyNewBlock."""
     
     def test_basic_functionality(self):
         """Test basic block functionality."""
-        block = BlockRegistry.get_block("MyNewBlock")(
+        block = MyNewBlock(
             block_name="test_block",
             input_cols=["input"],
             output_cols=["output"]
@@ -149,7 +150,7 @@ class TestMyNewBlock:
     def test_configuration_validation(self):
         """Test parameter validation."""
         with pytest.raises(ValueError):
-            BlockRegistry.get_block("MyNewBlock")(
+            MyNewBlock(
                 block_name="bad_config",
                 input_cols=["input"],
                 output_cols=["output"],
@@ -158,7 +159,7 @@ class TestMyNewBlock:
     
     def test_missing_columns(self):
         """Test error handling for missing columns."""
-        block = BlockRegistry.get_block("MyNewBlock")(
+        block = MyNewBlock(
             block_name="test_block",
             input_cols=["missing_column"],
             output_cols=["output"]

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -108,10 +108,10 @@ eval_flows = FlowRegistry.search_flows(tag="evaluation")
 print(f"📊 Evaluation Flows: {eval_flows}")
 
 # Find blocks by category
-llm_blocks = BlockRegistry.search_blocks(category="llm")
+llm_blocks = BlockRegistry.category("llm")
 print(f"🧠 LLM Blocks: {llm_blocks}")
 
-transform_blocks = BlockRegistry.search_blocks(category="transform") 
+transform_blocks = BlockRegistry.category("transform") 
 print(f"🔄 Transform Blocks: {transform_blocks}")
 ```
 

--- a/src/sdg_hub/core/blocks/registry.py
+++ b/src/sdg_hub/core/blocks/registry.py
@@ -164,8 +164,10 @@ class BlockRegistry:
                 ) from exc
 
     @classmethod
-    def get(cls, block_name: str) -> type:
-        """Get a block class with enhanced error handling.
+    def _get(cls, block_name: str) -> type:
+        """Internal method to get a block class with enhanced error handling.
+
+        This is a private method used by the framework internals (Flow system).
 
         Parameters
         ----------

--- a/src/sdg_hub/core/flow/base.py
+++ b/src/sdg_hub/core/flow/base.py
@@ -306,7 +306,7 @@ class Flow(BaseModel):
 
         # Get block class from registry
         try:
-            block_class = BlockRegistry.get(block_type_name)
+            block_class = BlockRegistry._get(block_type_name)
         except KeyError as exc:
             # Get all available blocks from all categories
             all_blocks = BlockRegistry.all()

--- a/tests/blocks/evaluation/test_evaluate_faithfulness_block.py
+++ b/tests/blocks/evaluation/test_evaluate_faithfulness_block.py
@@ -65,7 +65,7 @@ class TestEvaluateFaithfulnessBlock:
 
     def test_block_registry(self):
         """Test that EvaluateFaithfulnessBlock is properly registered."""
-        block_class = BlockRegistry.get("EvaluateFaithfulnessBlock")
+        block_class = BlockRegistry._get("EvaluateFaithfulnessBlock")
         assert block_class == EvaluateFaithfulnessBlock
 
         # Check category

--- a/tests/blocks/evaluation/test_evaluate_relevancy_block.py
+++ b/tests/blocks/evaluation/test_evaluate_relevancy_block.py
@@ -65,7 +65,7 @@ class TestEvaluateRelevancyBlock:
 
     def test_block_registry(self):
         """Test that EvaluateRelevancyBlock is properly registered."""
-        block_class = BlockRegistry.get("EvaluateRelevancyBlock")
+        block_class = BlockRegistry._get("EvaluateRelevancyBlock")
         assert block_class == EvaluateRelevancyBlock
 
         # Check category

--- a/tests/blocks/evaluation/test_verify_question_block.py
+++ b/tests/blocks/evaluation/test_verify_question_block.py
@@ -57,7 +57,7 @@ class TestVerifyQuestionBlock:
 
     def test_block_registry(self):
         """Test that VerifyQuestionBlock is properly registered."""
-        block_class = BlockRegistry.get("VerifyQuestionBlock")
+        block_class = BlockRegistry._get("VerifyQuestionBlock")
         assert block_class == VerifyQuestionBlock
 
         # Check category

--- a/tests/blocks/test_registry.py
+++ b/tests/blocks/test_registry.py
@@ -169,13 +169,13 @@ class TestBlockRegistry:
             def generate(self, samples: Dataset, **kwargs) -> Dataset:
                 return samples
 
-        retrieved_class = BlockRegistry.get("TestBlock")
+        retrieved_class = BlockRegistry._get("TestBlock")
         assert retrieved_class == TestBlock
 
     def test_get_block_class_not_found(self):
         """Test error when block not found."""
         with pytest.raises(KeyError) as exc_info:
-            BlockRegistry.get("NonExistentBlock")
+            BlockRegistry._get("NonExistentBlock")
 
         error_msg = str(exc_info.value)
         assert "NonExistentBlock" in error_msg
@@ -190,7 +190,7 @@ class TestBlockRegistry:
                 return samples
 
         with pytest.raises(KeyError) as exc_info:
-            BlockRegistry.get("TestBloc")  # Missing 'k'
+            BlockRegistry._get("TestBloc")  # Missing 'k'
 
         error_msg = str(exc_info.value)
         assert "Did you mean: TestBlock" in error_msg
@@ -209,7 +209,7 @@ class TestBlockRegistry:
             # Clear previous calls from registration
             mock_logger.reset_mock()
 
-            retrieved_class = BlockRegistry.get("OldBlock")
+            retrieved_class = BlockRegistry._get("OldBlock")
             assert retrieved_class == OldBlock
 
             # Check deprecation warning was logged
@@ -391,7 +391,7 @@ class TestBlockRegistry:
                 return samples
 
         with pytest.raises(KeyError) as exc_info:
-            BlockRegistry.get("NonExistentBlock")
+            BlockRegistry._get("NonExistentBlock")
 
         error_msg = str(exc_info.value)
         assert "Available blocks: ExistingBlock" in error_msg

--- a/tests/flow/conftest.py
+++ b/tests/flow/conftest.py
@@ -188,7 +188,7 @@ def mock_block_registry():
             mock_class.return_value = mock_instance
             return mock_class
 
-        mock_registry.get.side_effect = mock_get
+        mock_registry._get.side_effect = mock_get
         mock_registry.list_blocks.return_value = ["LLMChatBlock", "MockBlock"]
 
         yield mock_registry

--- a/tests/flow/test_base.py
+++ b/tests/flow/test_base.py
@@ -160,7 +160,7 @@ class TestFlow:
             yaml.dump(flow_config, f)
 
         # Mock the block creation
-        with patch("sdg_hub.core.flow.base.BlockRegistry.get") as mock_get:
+        with patch("sdg_hub.core.flow.base.BlockRegistry._get") as mock_get:
             mock_block_class = Mock()
             mock_block_instance = self.create_mock_block("test_block")
             mock_block_class.return_value = mock_block_instance
@@ -216,7 +216,7 @@ class TestFlow:
             yaml.dump(flow_config, f)
 
         # Mock the block creation
-        with patch("sdg_hub.core.flow.base.BlockRegistry.get") as mock_get:
+        with patch("sdg_hub.core.flow.base.BlockRegistry._get") as mock_get:
             mock_block_class = Mock()
             mock_block_instance = self.create_mock_block("test_block")
             mock_block_class.return_value = mock_block_instance

--- a/tests/flow/test_integration.py
+++ b/tests/flow/test_integration.py
@@ -85,7 +85,7 @@ class TestFlowIntegration:
                 mock_class.return_value = mock_instance
                 return mock_class
 
-            mock_registry.get.side_effect = mock_get
+            mock_registry._get.side_effect = mock_get
 
             # Load the flow
             flow = Flow.from_yaml(str(yaml_path))
@@ -386,7 +386,7 @@ class TestFlowIntegration:
                 mock_class.return_value = mock_instance
                 return mock_class
 
-            mock_registry.get.side_effect = mock_get
+            mock_registry._get.side_effect = mock_get
 
             # Load the flow
             flow = Flow.from_yaml(str(yaml_path))


### PR DESCRIPTION
## Purpose

Make BlockRegistry.get() private to prevent users from using string-based dynamic class lookup anti-patterns, while preserving functionality needed by the Flow system.

## Changes Made

**API Changes:**
- `src/sdg_hub/core/blocks/registry.py`: Renamed `get()` to `_get()` (private method)
- `src/sdg_hub/core/flow/base.py`: Updated Flow system to use `_get()`
- Updated all test files and mocks to use private method

**Documentation Fixes:**
- `docs/blocks/overview.md`: Fixed import paths and method examples
- `docs/blocks/llm-blocks.md`: Fixed import paths  
- `docs/development.md`: Updated test examples to use direct imports
- `docs/quick-start.md`: Fixed non-existent `search_blocks()` references

## Usage

Instead of string-based lookup (discouraged):
```python
# Don't do this
block_class = BlockRegistry.get_block("LLMChatBlock")  # Non-existent method
```

Use direct imports (recommended):
```python
# Do this instead
from sdg_hub.core.blocks import LLMChatBlock
block = LLMChatBlock(model="openai/gpt-4o", ...)
```

The Flow system continues to work as before using the private `_get()` method internally.