### PR TITLE
refactor(blocks): remove BlockRegistry.info to standardize  BaseBlock…

### DIFF
--- a/src/sdg_hub/core/blocks/registry.py
+++ b/src/sdg_hub/core/blocks/registry.py
@@ -215,29 +215,7 @@ class BlockRegistry:
             logger.warning(warning_msg)
 
         return metadata.block_class
-
-    @classmethod
-    def info(cls, block_name: str) -> BlockMetadata:
-        """Get metadata for a specific block.
-
-        Parameters
-        ----------
-        block_name : str
-            Name of the block.
-
-        Returns
-        -------
-        BlockMetadata
-            The block's metadata.
-
-        Raises
-        ------
-        KeyError
-            If the block is not found.
-        """
-        if block_name not in cls._metadata:
-            raise KeyError(f"Block '{block_name}' not found in registry.")
-        return cls._metadata[block_name]
+        
 
     @classmethod
     def categories(cls) -> list[str]:

--- a/tests/blocks/test_registry.py
+++ b/tests/blocks/test_registry.py
@@ -218,24 +218,7 @@ class TestBlockRegistry:
             assert "deprecated" in call_args
             assert "NewBlock" in call_args
 
-    def test_get_metadata(self):
-        """Test retrieving block metadata."""
-
-        @BlockRegistry.register("TestBlock", "test", "A test block")
-        class TestBlock(BaseBlock):
-            def generate(self, samples: Dataset, **kwargs) -> Dataset:
-                return samples
-
-        metadata = BlockRegistry.info("TestBlock")
-        assert metadata.name == "TestBlock"
-        assert metadata.category == "test"
-        assert metadata.description == "A test block"
-
-    def test_get_metadata_not_found(self):
-        """Test error when metadata not found."""
-        with pytest.raises(KeyError, match="'NonExistentBlock' not found in registry"):
-            BlockRegistry.info("NonExistentBlock")
-
+   
     def test_get_categories(self):
         """Test getting all categories."""
 


### PR DESCRIPTION
….get_info for block information

### Changes
- Removed `BlockRegistry.info` class method
- Updated all internal references 

### Reason
- `BlockRegistry.info` was redundant 
-  Standardizing on `BaseBlock.get_info` simplifies code maintenance

### Verification
- Ran all unit tests and they pass
