### PR TITLE
Remove openai dependency in annotation example and add yaml export example

### DIFF
--- a/examples/annotation/annotation_classification.ipynb
+++ b/examples/annotation/annotation_classification.ipynb
@@ -19,7 +19,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/lab/esivaram/sdg_hub/venv/lib64/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "/home/vpcuser/esivaram/sdg_hub/venv/lib64/python3.11/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
       "  from .autonotebook import tqdm as notebook_tqdm\n"
      ]
     }
@@ -68,7 +68,18 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Generating train split: 100%|██████████| 120000/120000 [00:00<00:00, 1376144.19 examples/s]\n",
+      "Generating test split: 100%|██████████| 7600/7600 [00:00<00:00, 1013858.03 examples/s]\n",
+      "Map: 100%|██████████| 500/500 [00:00<00:00, 18679.21 examples/s]\n",
+      "Map: 100%|██████████| 100/100 [00:00<00:00, 13883.37 examples/s]\n"
+     ]
+    }
+   ],
    "source": [
     "dataset = load_dataset(\"fancyzhx/ag_news\")\n",
     "\n",
@@ -201,7 +212,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Check if our LLM server is working"
+    "# Building a Simple Classification Flow\n",
+    "\n",
+    "### Discover Blocks for us to use\n",
+    "\n"
    ]
   },
   {
@@ -212,151 +226,103 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Connection successful! meta-llama/Llama-<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">3.3</span>-70B-Instruct: Hello. How can I help you today?\n",
-       "</pre>\n"
-      ],
-      "text/plain": [
-       "Connection successful! meta-llama/Llama-\u001b[1;36m3.3\u001b[0m-70B-Instruct: Hello. How can I help you today?\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "openai_api_key = \"EMPTY\" # replace with your inference server api key\n",
-    "openai_api_base = \"http://0.0.0.0:8000/v1\" # replace with your inference server endpoint\n",
-    "\n",
-    "\n",
-    "client = OpenAI(\n",
-    "    api_key=openai_api_key,\n",
-    "    base_url=openai_api_base,\n",
-    ")\n",
-    "\n",
-    "models = client.models.list()\n",
-    "teacher_model = models.data[0].id\n",
-    "\n",
-    "# Test the connection with a simple completion\n",
-    "response = client.chat.completions.create(\n",
-    "    model=teacher_model,\n",
-    "    messages=[{\"role\": \"user\", \"content\": \"Hello!\"}],\n",
-    "    temperature=0.0,\n",
-    "    max_tokens=10\n",
-    ")\n",
-    "completion = response.choices[0].message.content\n",
-    "\n",
-    "print(f\"Connection successful! {teacher_model}: {completion}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Building a Simple Classification Flow\n",
-    "\n",
-    "### Discover Blocks for us to use\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\"><span style=\"font-style: italic\">                                                 Available Blocks                                                  </span>\n",
-       "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓\n",
-       "┃<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> Block Name                </span>┃<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> Category   </span>┃<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> Description                                                            </span>┃\n",
-       "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\"> CombineColumnsBlock       </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> deprecated </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> DEPRECATED: Use TextConcatBlock instead. Combines multiple columns     </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\">                           </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> into a single column using a separator                                 </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\"> DuplicateColumns          </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> deprecated </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> DEPRECATED: Use DuplicateColumnsBlock instead. Duplicates existing     </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\">                           </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> columns with new names according to a mapping dictionary               </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\"> FilterByValueBlock        </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> deprecated </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> DEPRECATED: Use ColumnValueFilterBlock instead. Filters datasets based </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\">                           </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> on column values using various comparison operations                   </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\"> FlattenColumnsBlock       </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> deprecated </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> DEPRECATED: Use MeltColumnsBlock instead. Transforms wide dataset      </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\">                           </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> format into long format by melting columns into rows                   </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\"> LLMBlock                  </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> deprecated </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> DEPRECATED: Use the new modular approach with PromptBuilderBlock,      </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\">                           </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> LLMChatBlock, and TextParserBlock instead                              </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\"> RenameColumns             </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> deprecated </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> DEPRECATED: Use RenameColumnsBlock instead. Renames columns in a       </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\">                           </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> dataset according to a mapping dictionary                              </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\"> SamplePopulatorBlock      </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> deprecated </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> DEPRECATED: Use a router block instead. Populates dataset with data    </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\">                           </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> from configuration files                                               </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\"> SelectorBlock             </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> deprecated </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> DEPRECATED: Use IndexBasedMapperBlock instead. Selects and maps values </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\">                           </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> from one column to another                                             </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\"> SetToMajorityValue        </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> deprecated </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> DEPRECATED: Use UniformColumnValueSetter with                          </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\">                           </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> reduction_strategy='mode' instead. Sets all values in a column to the  </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\">                           </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> most frequent value                                                    </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\"> EvaluateFaithfulnessBlock </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> evaluation </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Composite block for faithfulness evaluation of question-answer pairs   </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\"> EvaluateRelevancyBlock    </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> evaluation </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Composite block for relevancy evaluation of question-answer pairs      </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\"> VerifyQuestionBlock       </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> evaluation </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Composite block for question verification and quality assessment       </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\"> ColumnValueFilterBlock    </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> filtering  </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Filters datasets based on column values using various comparison       </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\">                           </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> operations                                                             </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\"> LLMChatBlock              </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> llm        </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Unified LLM chat block supporting 100+ providers via LiteLLM           </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\"> PromptBuilderBlock        </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> llm        </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Formats prompts into structured chat messages or plain text using      </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\">                           </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Jinja templates                                                        </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\"> TextParserBlock           </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> llm        </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Parses and post-processes LLM outputs using tags or regex patterns     </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\"> DuplicateColumnsBlock     </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> transform  </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Duplicates existing columns with new names according to a mapping      </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\">                           </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> specification                                                          </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\"> IndexBasedMapperBlock     </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> transform  </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Maps values from source columns to output columns based on choice      </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\">                           </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> columns using shared mapping                                           </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\"> MeltColumnsBlock          </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> transform  </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Transforms wide dataset format into long format by melting columns     </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\">                           </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> into rows                                                              </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\"> RenameColumnsBlock        </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> transform  </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Renames columns in a dataset according to a mapping specification      </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\"> TextConcatBlock           </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> transform  </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Combines multiple columns into a single column using a specified       </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\">                           </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> separator                                                              </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\"> UniformColumnValueSetter  </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> transform  </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Replaces all values in a column with a single summary statistic (e.g., </span>│\n",
-       "│<span style=\"color: #008080; text-decoration-color: #008080\">                           </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> mode, mean, median)                                                    </span>│\n",
-       "└───────────────────────────┴────────────┴────────────────────────────────────────────────────────────────────────┘\n",
+       "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓\n",
+       "┃<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> Block Name                   </span>┃<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> Category   </span>┃<span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\"> Description                                                         </span>┃\n",
+       "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> CombineColumnsBlock          </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> deprecated </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> DEPRECATED: Use TextConcatBlock instead. Combines multiple columns  </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">                              </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> into a single column using a separator                              </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> DuplicateColumns             </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> deprecated </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> DEPRECATED: Use DuplicateColumnsBlock instead. Duplicates existing  </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">                              </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> columns with new names according to a mapping dictionary            </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> FilterByValueBlock           </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> deprecated </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> DEPRECATED: Use ColumnValueFilterBlock instead. Filters datasets    </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">                              </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> based on column values using various comparison operations          </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> FlattenColumnsBlock          </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> deprecated </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> DEPRECATED: Use MeltColumnsBlock instead. Transforms wide dataset   </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">                              </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> format into long format by melting columns into rows                </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> LLMBlock                     </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> deprecated </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> DEPRECATED: Use the new modular approach with PromptBuilderBlock,   </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">                              </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> LLMChatBlock, and TextParserBlock instead                           </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> RenameColumns                </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> deprecated </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> DEPRECATED: Use RenameColumnsBlock instead. Renames columns in a    </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">                              </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> dataset according to a mapping dictionary                           </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> SamplePopulatorBlock         </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> deprecated </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> DEPRECATED: Use a router block instead. Populates dataset with data </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">                              </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> from configuration files                                            </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> SelectorBlock                </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> deprecated </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> DEPRECATED: Use IndexBasedMapperBlock instead. Selects and maps     </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">                              </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> values from one column to another                                   </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> SetToMajorityValue           </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> deprecated </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> DEPRECATED: Use UniformColumnValueSetter with                       </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">                              </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> reduction_strategy='mode' instead. Sets all values in a column to   </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">                              </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> the most frequent value                                             </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> EvaluateFaithfulnessBlock    </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> evaluation </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Composite block for faithfulness evaluation of question-answer      </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">                              </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> pairs                                                               </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> EvaluateRelevancyBlock       </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> evaluation </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Composite block for relevancy evaluation of question-answer pairs   </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> VerifyQuestionBlock          </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> evaluation </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Composite block for question verification and quality assessment    </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> ColumnValueFilterBlock       </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> filtering  </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Filters datasets based on column values using various comparison    </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">                              </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> operations                                                          </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> LLMChatBlock                 </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> llm        </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Unified LLM chat block supporting 100+ providers via LiteLLM        </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> LLMChatWithParsingRetryBlock </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> llm        </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Composite block combining LLM chat and text parsing with automatic  </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">                              </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> retry on parsing failures                                           </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> PromptBuilderBlock           </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> llm        </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Formats prompts into structured chat messages or plain text using   </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">                              </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Jinja templates                                                     </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> TextParserBlock              </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> llm        </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Parses and post-processes LLM outputs using tags or regex patterns  </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> DuplicateColumnsBlock        </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> transform  </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Duplicates existing columns with new names according to a mapping   </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">                              </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> specification                                                       </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> IndexBasedMapperBlock        </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> transform  </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Maps values from source columns to output columns based on choice   </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">                              </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> columns using shared mapping                                        </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> MeltColumnsBlock             </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> transform  </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Transforms wide dataset format into long format by melting columns  </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">                              </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> into rows                                                           </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> RenameColumnsBlock           </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> transform  </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Renames columns in a dataset according to a mapping specification   </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> TextConcatBlock              </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> transform  </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Combines multiple columns into a single column using a specified    </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">                              </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> separator                                                           </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\"> UniformColumnValueSetter     </span>│<span style=\"color: #008000; text-decoration-color: #008000\"> transform  </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> Replaces all values in a column with a single summary statistic     </span>│\n",
+       "│<span style=\"color: #008080; text-decoration-color: #008080\">                              </span>│<span style=\"color: #008000; text-decoration-color: #008000\">            </span>│<span style=\"color: #c0c0c0; text-decoration-color: #c0c0c0\"> (e.g., mode, mean, median)                                          </span>│\n",
+       "└──────────────────────────────┴────────────┴─────────────────────────────────────────────────────────────────────┘\n",
        "</pre>\n"
       ],
       "text/plain": [
        "\u001b[3m                                                 Available Blocks                                                  \u001b[0m\n",
-       "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓\n",
-       "┃\u001b[1;35m \u001b[0m\u001b[1;35mBlock Name               \u001b[0m\u001b[1;35m \u001b[0m┃\u001b[1;35m \u001b[0m\u001b[1;35mCategory  \u001b[0m\u001b[1;35m \u001b[0m┃\u001b[1;35m \u001b[0m\u001b[1;35mDescription                                                           \u001b[0m\u001b[1;35m \u001b[0m┃\n",
-       "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩\n",
-       "│\u001b[36m \u001b[0m\u001b[36mCombineColumnsBlock      \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mdeprecated\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mDEPRECATED: Use TextConcatBlock instead. Combines multiple columns    \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m                           \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37minto a single column using a separator                                \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m \u001b[0m\u001b[36mDuplicateColumns         \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mdeprecated\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mDEPRECATED: Use DuplicateColumnsBlock instead. Duplicates existing    \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m                           \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mcolumns with new names according to a mapping dictionary              \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m \u001b[0m\u001b[36mFilterByValueBlock       \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mdeprecated\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mDEPRECATED: Use ColumnValueFilterBlock instead. Filters datasets based\u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m                           \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mon column values using various comparison operations                  \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m \u001b[0m\u001b[36mFlattenColumnsBlock      \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mdeprecated\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mDEPRECATED: Use MeltColumnsBlock instead. Transforms wide dataset     \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m                           \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mformat into long format by melting columns into rows                  \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m \u001b[0m\u001b[36mLLMBlock                 \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mdeprecated\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mDEPRECATED: Use the new modular approach with PromptBuilderBlock,     \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m                           \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mLLMChatBlock, and TextParserBlock instead                             \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m \u001b[0m\u001b[36mRenameColumns            \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mdeprecated\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mDEPRECATED: Use RenameColumnsBlock instead. Renames columns in a      \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m                           \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mdataset according to a mapping dictionary                             \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m \u001b[0m\u001b[36mSamplePopulatorBlock     \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mdeprecated\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mDEPRECATED: Use a router block instead. Populates dataset with data   \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m                           \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mfrom configuration files                                              \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m \u001b[0m\u001b[36mSelectorBlock            \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mdeprecated\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mDEPRECATED: Use IndexBasedMapperBlock instead. Selects and maps values\u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m                           \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mfrom one column to another                                            \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m \u001b[0m\u001b[36mSetToMajorityValue       \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mdeprecated\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mDEPRECATED: Use UniformColumnValueSetter with                         \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m                           \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mreduction_strategy='mode' instead. Sets all values in a column to the \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m                           \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mmost frequent value                                                   \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m \u001b[0m\u001b[36mEvaluateFaithfulnessBlock\u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mevaluation\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mComposite block for faithfulness evaluation of question-answer pairs  \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m \u001b[0m\u001b[36mEvaluateRelevancyBlock   \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mevaluation\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mComposite block for relevancy evaluation of question-answer pairs     \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m \u001b[0m\u001b[36mVerifyQuestionBlock      \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mevaluation\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mComposite block for question verification and quality assessment      \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m \u001b[0m\u001b[36mColumnValueFilterBlock   \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mfiltering \u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mFilters datasets based on column values using various comparison      \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m                           \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37moperations                                                            \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m \u001b[0m\u001b[36mLLMChatBlock             \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mllm       \u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mUnified LLM chat block supporting 100+ providers via LiteLLM          \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m \u001b[0m\u001b[36mPromptBuilderBlock       \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mllm       \u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mFormats prompts into structured chat messages or plain text using     \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m                           \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mJinja templates                                                       \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m \u001b[0m\u001b[36mTextParserBlock          \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mllm       \u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mParses and post-processes LLM outputs using tags or regex patterns    \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m \u001b[0m\u001b[36mDuplicateColumnsBlock    \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mtransform \u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mDuplicates existing columns with new names according to a mapping     \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m                           \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mspecification                                                         \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m \u001b[0m\u001b[36mIndexBasedMapperBlock    \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mtransform \u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mMaps values from source columns to output columns based on choice     \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m                           \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mcolumns using shared mapping                                          \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m \u001b[0m\u001b[36mMeltColumnsBlock         \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mtransform \u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mTransforms wide dataset format into long format by melting columns    \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m                           \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37minto rows                                                             \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m \u001b[0m\u001b[36mRenameColumnsBlock       \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mtransform \u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mRenames columns in a dataset according to a mapping specification     \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m \u001b[0m\u001b[36mTextConcatBlock          \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mtransform \u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mCombines multiple columns into a single column using a specified      \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m                           \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mseparator                                                             \u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m \u001b[0m\u001b[36mUniformColumnValueSetter \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mtransform \u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mReplaces all values in a column with a single summary statistic (e.g.,\u001b[0m\u001b[37m \u001b[0m│\n",
-       "│\u001b[36m                           \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mmode, mean, median)                                                   \u001b[0m\u001b[37m \u001b[0m│\n",
-       "└───────────────────────────┴────────────┴────────────────────────────────────────────────────────────────────────┘\n"
+       "┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓\n",
+       "┃\u001b[1;35m \u001b[0m\u001b[1;35mBlock Name                  \u001b[0m\u001b[1;35m \u001b[0m┃\u001b[1;35m \u001b[0m\u001b[1;35mCategory  \u001b[0m\u001b[1;35m \u001b[0m┃\u001b[1;35m \u001b[0m\u001b[1;35mDescription                                                        \u001b[0m\u001b[1;35m \u001b[0m┃\n",
+       "┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩\n",
+       "│\u001b[36m \u001b[0m\u001b[36mCombineColumnsBlock         \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mdeprecated\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mDEPRECATED: Use TextConcatBlock instead. Combines multiple columns \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m                              \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37minto a single column using a separator                             \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36mDuplicateColumns            \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mdeprecated\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mDEPRECATED: Use DuplicateColumnsBlock instead. Duplicates existing \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m                              \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mcolumns with new names according to a mapping dictionary           \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36mFilterByValueBlock          \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mdeprecated\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mDEPRECATED: Use ColumnValueFilterBlock instead. Filters datasets   \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m                              \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mbased on column values using various comparison operations         \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36mFlattenColumnsBlock         \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mdeprecated\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mDEPRECATED: Use MeltColumnsBlock instead. Transforms wide dataset  \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m                              \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mformat into long format by melting columns into rows               \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36mLLMBlock                    \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mdeprecated\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mDEPRECATED: Use the new modular approach with PromptBuilderBlock,  \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m                              \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mLLMChatBlock, and TextParserBlock instead                          \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36mRenameColumns               \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mdeprecated\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mDEPRECATED: Use RenameColumnsBlock instead. Renames columns in a   \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m                              \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mdataset according to a mapping dictionary                          \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36mSamplePopulatorBlock        \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mdeprecated\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mDEPRECATED: Use a router block instead. Populates dataset with data\u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m                              \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mfrom configuration files                                           \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36mSelectorBlock               \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mdeprecated\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mDEPRECATED: Use IndexBasedMapperBlock instead. Selects and maps    \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m                              \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mvalues from one column to another                                  \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36mSetToMajorityValue          \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mdeprecated\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mDEPRECATED: Use UniformColumnValueSetter with                      \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m                              \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mreduction_strategy='mode' instead. Sets all values in a column to  \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m                              \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mthe most frequent value                                            \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36mEvaluateFaithfulnessBlock   \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mevaluation\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mComposite block for faithfulness evaluation of question-answer     \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m                              \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mpairs                                                              \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36mEvaluateRelevancyBlock      \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mevaluation\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mComposite block for relevancy evaluation of question-answer pairs  \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36mVerifyQuestionBlock         \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mevaluation\u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mComposite block for question verification and quality assessment   \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36mColumnValueFilterBlock      \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mfiltering \u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mFilters datasets based on column values using various comparison   \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m                              \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37moperations                                                         \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36mLLMChatBlock                \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mllm       \u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mUnified LLM chat block supporting 100+ providers via LiteLLM       \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36mLLMChatWithParsingRetryBlock\u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mllm       \u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mComposite block combining LLM chat and text parsing with automatic \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m                              \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mretry on parsing failures                                          \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36mPromptBuilderBlock          \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mllm       \u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mFormats prompts into structured chat messages or plain text using  \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m                              \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mJinja templates                                                    \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36mTextParserBlock             \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mllm       \u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mParses and post-processes LLM outputs using tags or regex patterns \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36mDuplicateColumnsBlock       \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mtransform \u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mDuplicates existing columns with new names according to a mapping  \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m                              \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mspecification                                                      \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36mIndexBasedMapperBlock       \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mtransform \u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mMaps values from source columns to output columns based on choice  \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m                              \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mcolumns using shared mapping                                       \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36mMeltColumnsBlock            \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mtransform \u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mTransforms wide dataset format into long format by melting columns \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m                              \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37minto rows                                                          \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36mRenameColumnsBlock          \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mtransform \u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mRenames columns in a dataset according to a mapping specification  \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36mTextConcatBlock             \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mtransform \u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mCombines multiple columns into a single column using a specified   \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m                              \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37mseparator                                                          \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m \u001b[0m\u001b[36mUniformColumnValueSetter    \u001b[0m\u001b[36m \u001b[0m│\u001b[32m \u001b[0m\u001b[32mtransform \u001b[0m\u001b[32m \u001b[0m│\u001b[37m \u001b[0m\u001b[37mReplaces all values in a column with a single summary statistic    \u001b[0m\u001b[37m \u001b[0m│\n",
+       "│\u001b[36m                              \u001b[0m│\u001b[32m            \u001b[0m│\u001b[37m \u001b[0m\u001b[37m(e.g., mode, mean, median)                                         \u001b[0m\u001b[37m \u001b[0m│\n",
+       "└──────────────────────────────┴────────────┴─────────────────────────────────────────────────────────────────────┘\n"
       ]
      },
      "metadata": {},
@@ -366,12 +332,12 @@
      "data": {
       "text/html": [
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">\n",
-       "<span style=\"font-weight: bold\">Summary:</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">22</span> blocks across <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span> categories\n",
+       "<span style=\"font-weight: bold\">Summary:</span> <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">23</span> blocks across <span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5</span> categories\n",
        "</pre>\n"
       ],
       "text/plain": [
        "\n",
-       "\u001b[1mSummary:\u001b[0m \u001b[1;36m22\u001b[0m blocks across \u001b[1;36m5\u001b[0m categories\n"
+       "\u001b[1mSummary:\u001b[0m \u001b[1;36m23\u001b[0m blocks across \u001b[1;36m5\u001b[0m categories\n"
       ]
      },
      "metadata": {},
@@ -459,7 +425,9 @@
    "source": [
     "### Set the model configs for the `Flow`\n",
     "\n",
-    "In SDG Hub, model details such as the API base URL, the API Key (if any) and the model name are set at a Flow level using the `set_model_config` method as shown. The `model` parameter accepts a string in the format of \"`provider`/`model_name`\". Here our `provider` is 'hosted_vllm' as we are using a self hosted model through vllm, and the model name is \"meta-llama/Llama-3.3-70B-Instruct\""
+    "In SDG Hub, model details such as the API base URL, the API Key (if any) and the model name are set at a Flow level using the `set_model_config` method as shown. The `model` parameter accepts a string in the format of \"`provider`/`model_name`\". Here our `provider` is 'hosted_vllm' as we are using a locally hosted model through vllm, and the model name is \"meta-llama/Llama-3.3-70B-Instruct\"\n",
+    "\n",
+    "We must set the `api_base` parameter and point it to where the model endpoint can be found, in this case, `http://localhost:8000/v1`"
    ]
   },
   {
@@ -716,7 +684,7 @@
     "llmchatblock_revision = LLMChatBlock(block_name='revised_llm_chat_block', input_cols=['revised_prompt'], output_cols=['raw_revised_output'], temperature=0.0, max_tokens=5, extra_body={'guided_choice': ['World', 'Sports', 'Business', 'Sci/Tech']}, async_mode=True)\n",
     "textparserblock_revision = TextParserBlock(block_name='revised_text_parser_block', input_cols=['raw_revised_output'], output_cols=['revised_output'], start_tags=[''], end_tags=[''])\n",
     "\n",
-    "flow = Flow(blocks=[promptbuilderblock_1, llmchatblock_1, textparserblock_1, promptbuilderblock_assessment, llmchatblock_assessment, textparserblock_assessment, promptbuilderblock_revision, llmchatblock_revision, textparserblock_revision], metadata=FlowMetadata(name=\"annotation_flow\", description=\"A flow for news article classification\", author=\"sdg_hub\"))\n",
+    "flow = Flow(blocks=[promptbuilderblock_1, llmchatblock_1, textparserblock_1, promptbuilderblock_assessment, llmchatblock_assessment, textparserblock_assessment, promptbuilderblock_revision, llmchatblock_revision, textparserblock_revision], metadata=FlowMetadata(name=\"news_classification_flow\", description=\"A flow for news article classification with assessment and revision\", author=\"sdg_hub\"))\n",
     "flow.set_model_config(model=\"hosted_vllm/meta-llama/Llama-3.3-70B-Instruct\", api_base=\"http://localhost:8000/v1\", api_key=\"\")"
    ]
   },
@@ -824,6 +792,22 @@
    "metadata": {},
    "source": [
     "Great, we whave now improved the classification accuracy of our system by augmenting our naive classification flow by adding an assessment followed by a revision step\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Export the flow to yaml form\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flow.to_yaml(\"news_classification_flow.yaml\")"
    ]
   },
   {

--- a/examples/annotation/news_classification_flow.yaml
+++ b/examples/annotation/news_classification_flow.yaml
@@ -1,0 +1,185 @@
+metadata:
+  name: news_classification_flow
+  id: open-forest-413
+  description: A flow for news article classification with assessment and revision
+  version: 1.0.0
+  author: sdg_hub
+  recommended_models: null
+  tags: []
+  created_at: '2025-08-19T21:19:34.860381'
+  updated_at: '2025-08-19T21:19:34.860389'
+  license: Apache-2.0
+  min_sdg_hub_version: ''
+  dataset_requirements: null
+  estimated_cost: medium
+  estimated_duration: ''
+blocks:
+- block_type: PromptBuilderBlock
+  block_config:
+    block_name: annotation_prompt_builder
+    input_cols:
+    - text
+    output_cols:
+    - annotation_prompt
+    prompt_config_path: news_classification_prompt.yaml
+    format_as_messages: true
+- block_type: LLMChatBlock
+  block_config:
+    block_name: annotation_llm_chat_block
+    input_cols:
+    - annotation_prompt
+    output_cols:
+    - raw_output
+    model: hosted_vllm/meta-llama/Llama-3.3-70B-Instruct
+    api_key: ''
+    api_base: http://localhost:8000/v1
+    async_mode: true
+    timeout: 120.0
+    max_retries: 6
+    temperature: 0.0
+    max_tokens: 5
+    top_p: null
+    frequency_penalty: null
+    presence_penalty: null
+    stop: null
+    seed: null
+    response_format: null
+    stream: null
+    n: null
+    logprobs: null
+    top_logprobs: null
+    user: null
+    extra_headers: null
+    extra_body:
+      guided_choice:
+      - World
+      - Sports
+      - Business
+      - Sci/Tech
+    provider_specific: null
+- block_type: TextParserBlock
+  block_config:
+    block_name: annotation_text_parser_block
+    input_cols:
+    - raw_output
+    output_cols:
+    - output
+    start_tags:
+    - ''
+    end_tags:
+    - ''
+    parsing_pattern: null
+    parser_cleanup_tags: null
+    expand_lists: true
+- block_type: PromptBuilderBlock
+  block_config:
+    block_name: verifier_prompt_builder
+    input_cols:
+    - text
+    - output
+    output_cols:
+    - assessment_prompt
+    prompt_config_path: news_classification_assessment_prompt.yaml
+    format_as_messages: true
+- block_type: LLMChatBlock
+  block_config:
+    block_name: verifier_llm_chat_block
+    input_cols:
+    - assessment_prompt
+    output_cols:
+    - raw_assessment_output
+    model: hosted_vllm/meta-llama/Llama-3.3-70B-Instruct
+    api_key: ''
+    api_base: http://localhost:8000/v1
+    async_mode: true
+    timeout: 120.0
+    max_retries: 6
+    temperature: null
+    max_tokens: null
+    top_p: null
+    frequency_penalty: null
+    presence_penalty: null
+    stop: null
+    seed: null
+    response_format: null
+    stream: null
+    n: null
+    logprobs: null
+    top_logprobs: null
+    user: null
+    extra_headers: null
+    extra_body: null
+    provider_specific: null
+- block_type: TextParserBlock
+  block_config:
+    block_name: verifier_text_parser_block
+    input_cols:
+    - raw_assessment_output
+    output_cols:
+    - assessment_output
+    start_tags:
+    - ''
+    end_tags:
+    - ''
+    parsing_pattern: null
+    parser_cleanup_tags: null
+    expand_lists: true
+- block_type: PromptBuilderBlock
+  block_config:
+    block_name: revised_prompt_builder
+    input_cols:
+    - text
+    - output
+    - assessment_output
+    output_cols:
+    - revised_prompt
+    prompt_config_path: revise_news_classification_prompt.yaml
+    format_as_messages: true
+- block_type: LLMChatBlock
+  block_config:
+    block_name: revised_llm_chat_block
+    input_cols:
+    - revised_prompt
+    output_cols:
+    - raw_revised_output
+    model: hosted_vllm/meta-llama/Llama-3.3-70B-Instruct
+    api_key: ''
+    api_base: http://localhost:8000/v1
+    async_mode: true
+    timeout: 120.0
+    max_retries: 6
+    temperature: 0.0
+    max_tokens: 5
+    top_p: null
+    frequency_penalty: null
+    presence_penalty: null
+    stop: null
+    seed: null
+    response_format: null
+    stream: null
+    n: null
+    logprobs: null
+    top_logprobs: null
+    user: null
+    extra_headers: null
+    extra_body:
+      guided_choice:
+      - World
+      - Sports
+      - Business
+      - Sci/Tech
+    provider_specific: null
+- block_type: TextParserBlock
+  block_config:
+    block_name: revised_text_parser_block
+    input_cols:
+    - raw_revised_output
+    output_cols:
+    - revised_output
+    start_tags:
+    - ''
+    end_tags:
+    - ''
+    parsing_pattern: null
+    parser_cleanup_tags: null
+    expand_lists: true


### PR DESCRIPTION
# Enhance annotation classification notebook and add YAML export functionality
## Changes Made:
- Removed OpenAI dependency cell - Eliminated the "Check if our LLM server is working" section that was testing OpenAI connectivity
- Added YAML export capability - New cell to export the flow configuration using `flow.to_yaml("news_classification_flow.yaml")`
- Generated showcase YAML file - Created `news_classification_flow.yaml` (185 lines) containing the complete flow configuration
- Updated flow metadata - Changed flow name from "annotation_flow" to "news_classification_flow" and improved description
- Enhanced documentation - Added clarification about setting api_base parameter for locally hosted models

## Impact:
- Cleaner notebook without external API dependencies
- Provides reusable YAML configuration for the news classification flow
- Better showcases the flow export functionality for users
- Improved flow naming and documentation

This change makes the notebook more self-contained and demonstrates the YAML export feature while removing unnecessary external dependencies.