### PR TITLE
Pass extra_headers and extra_body to all LLMChatBlocks

### DIFF
--- a/src/sdg_hub/core/blocks/evaluation/evaluate_faithfulness_block.py
+++ b/src/sdg_hub/core/blocks/evaluation/evaluate_faithfulness_block.py
@@ -360,6 +360,8 @@ class EvaluateFaithfulnessBlock(BaseBlock):
             self.llm_chat.model = self.model
             self.llm_chat.api_base = self.api_base
             self.llm_chat.api_key = self.api_key
+            self.llm_chat.extra_headers = self.extra_headers
+            self.llm_chat.extra_body = self.extra_body
             # Reinitialize its client manager
             self.llm_chat._reinitialize_client_manager()
 

--- a/src/sdg_hub/core/blocks/evaluation/evaluate_relevancy_block.py
+++ b/src/sdg_hub/core/blocks/evaluation/evaluate_relevancy_block.py
@@ -360,6 +360,8 @@ class EvaluateRelevancyBlock(BaseBlock):
             self.llm_chat.model = self.model
             self.llm_chat.api_base = self.api_base
             self.llm_chat.api_key = self.api_key
+            self.llm_chat.extra_headers = self.extra_headers
+            self.llm_chat.extra_body = self.extra_body
             # Reinitialize its client manager
             self.llm_chat._reinitialize_client_manager()
 

--- a/src/sdg_hub/core/blocks/evaluation/verify_question_block.py
+++ b/src/sdg_hub/core/blocks/evaluation/verify_question_block.py
@@ -360,6 +360,8 @@ class VerifyQuestionBlock(BaseBlock):
             self.llm_chat.model = self.model
             self.llm_chat.api_base = self.api_base
             self.llm_chat.api_key = self.api_key
+            self.llm_chat.extra_headers = self.extra_headers
+            self.llm_chat.extra_body = self.extra_body
             # Reinitialize its client manager
             self.llm_chat._reinitialize_client_manager()
 

--- a/src/sdg_hub/core/blocks/llm/llm_chat_with_parsing_retry_block.py
+++ b/src/sdg_hub/core/blocks/llm/llm_chat_with_parsing_retry_block.py
@@ -246,7 +246,7 @@ class LLMChatWithParsingRetryBlock(BaseBlock):
         """
         if self.llm_chat and hasattr(self.llm_chat, "_reinitialize_client_manager"):
             # Update the internal LLM chat block's model config from stored params
-            for key in ["model", "api_base", "api_key"]:
+            for key in ["model", "api_base", "api_key", "extra_headers", "extra_body"]:
                 if key in self.llm_params:
                     setattr(self.llm_chat, key, self.llm_params[key])
             # Reinitialize its client manager


### PR DESCRIPTION
I have a model server that requires `extra_headers` in every call.
By configuring it as follows, we can pass `extra_headers` to some `LLMChatBlock`s.
```python
flow.set_model_config(
    model="hosted_vllm/meta-llama/Llama-3.3-70B-Instruct",
    api_base="http://localhost:8000/v1",
    api_key="EMPTY",
    extra_headers={"XXX":"YYY"},
)
```
This PR is intended to pass `extra_headers` (and `extra_body`) to all `LLMChatBlock`s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Evaluation and verification blocks now correctly apply custom HTTP headers and request body settings to underlying LLM requests, ensuring configurations are honored during reinitialization.
  * Improves compatibility with custom API gateways and providers by propagating these settings throughout internal chat operations, leading to more reliable request construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->