### PR TITLE
 fix(flows): adding deduplicate row validation 

### DIFF
--- a/src/sdg_hub/core/flow/base.py
+++ b/src/sdg_hub/core/flow/base.py
@@ -18,7 +18,7 @@ import yaml
 # Local
 from ..blocks.base import BaseBlock
 from ..blocks.registry import BlockRegistry
-from ..utils.datautils import safe_concatenate_with_validation
+from ..utils.datautils import safe_concatenate_with_validation, validate_no_duplicates
 from ..utils.error_handling import EmptyDatasetError, FlowValidationError
 from ..utils.logger_config import setup_logger
 from ..utils.path_resolution import resolve_path
@@ -403,6 +403,8 @@ class Flow(BaseModel):
 
         if len(dataset) == 0:
             raise EmptyDatasetError("Input dataset is empty")
+
+        validate_no_duplicates(dataset)
 
         # Check if model configuration has been set for flows with LLM blocks
         llm_blocks = self._detect_llm_blocks()

--- a/src/sdg_hub/core/flow/base.py
+++ b/src/sdg_hub/core/flow/base.py
@@ -901,6 +901,8 @@ class Flow(BaseModel):
         if len(dataset) == 0:
             raise EmptyDatasetError("Input dataset is empty")
 
+        validate_no_duplicates(dataset)
+
         # Use smaller sample size if dataset is smaller
         actual_sample_size = min(sample_size, len(dataset))
 

--- a/src/sdg_hub/core/utils/datautils.py
+++ b/src/sdg_hub/core/utils/datautils.py
@@ -15,6 +15,36 @@ def safe_concatenate_datasets(datasets: list):
     return concatenate_datasets(filtered_datasets)
 
 
+def validate_no_duplicates(dataset):
+    """
+    Validate that the input dataset contains only unique rows.
+
+    Uses pandas `.drop_duplicates()` for efficient duplicate detection.
+    Raises FlowValidationError if duplicates are found, including a count
+    of the duplicate rows detected.
+
+    Parameters
+    ----------
+    dataset : Dataset
+        Input dataset to validate.
+
+    Raises
+    ------
+    FlowValidationError
+        If duplicate rows are detected in the dataset.
+    """
+    input_data = dataset.to_pandas()
+    unique_data = input_data.drop_duplicates()
+
+    if len(input_data) != len(unique_data):
+        duplicate_count = len(input_data) - len(unique_data)
+        raise FlowValidationError(
+            f"Input dataset contains {duplicate_count} duplicate rows. "
+            f"SDG Hub operations require unique input rows. "
+            f"Please deduplicate your dataset before processing."
+        )
+
+
 def safe_concatenate_with_validation(
     datasets: list, context: str = "datasets"
 ) -> Dataset:

--- a/src/sdg_hub/core/utils/datautils.py
+++ b/src/sdg_hub/core/utils/datautils.py
@@ -15,11 +15,11 @@ def safe_concatenate_datasets(datasets: list):
     return concatenate_datasets(filtered_datasets)
 
 
-def validate_no_duplicates(dataset):
+def validate_no_duplicates(dataset: Dataset) -> None:
     """
     Validate that the input dataset contains only unique rows.
 
-    Uses pandas `.drop_duplicates()` for efficient duplicate detection.
+    Uses pandas `.duplicated()` for efficient duplicate detection.
     Raises FlowValidationError if duplicates are found, including a count
     of the duplicate rows detected.
 
@@ -33,11 +33,10 @@ def validate_no_duplicates(dataset):
     FlowValidationError
         If duplicate rows are detected in the dataset.
     """
-    input_data = dataset.to_pandas()
-    unique_data = input_data.drop_duplicates()
+    df = dataset.to_pandas()
+    duplicate_count = int(df.duplicated(keep="first").sum())
 
-    if len(input_data) != len(unique_data):
-        duplicate_count = len(input_data) - len(unique_data)
+    if duplicate_count > 0:
         raise FlowValidationError(
             f"Input dataset contains {duplicate_count} duplicate rows. "
             f"SDG Hub operations require unique input rows. "

--- a/tests/utils/test_datautils.py
+++ b/tests/utils/test_datautils.py
@@ -1,0 +1,43 @@
+# Third Party
+import pytest
+from datasets import Dataset
+
+# First Party
+from sdg_hub.core.utils.datautils import validate_no_duplicates
+from sdg_hub.core.utils.error_handling import FlowValidationError
+
+
+def test_validate_no_duplicates_with_unique_data():
+    """Test that no exception is raised for datasets with unique rows."""
+    dataset = Dataset.from_dict({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
+
+    # Should not raise any exception and return None
+    result = validate_no_duplicates(dataset)
+    assert result is None
+
+
+def test_validate_no_duplicates_with_duplicate_data():
+    """Test that FlowValidationError is raised for datasets with duplicate rows."""
+    dataset = Dataset.from_dict({"col1": [1, 2, 2, 3], "col2": ["a", "b", "b", "c"]})
+
+    with pytest.raises(FlowValidationError, match="contains 1 duplicate rows"):
+        validate_no_duplicates(dataset)
+
+
+def test_validate_no_duplicates_with_multiple_duplicates():
+    """Test correct duplicate count with multiple duplicate rows."""
+    dataset = Dataset.from_dict(
+        {"col1": [1, 1, 2, 2, 3], "col2": ["a", "a", "b", "b", "c"]}
+    )
+
+    with pytest.raises(FlowValidationError, match="contains 2 duplicate rows"):
+        validate_no_duplicates(dataset)
+
+
+def test_validate_no_duplicates_empty_dataset():
+    """Test that empty datasets pass validation."""
+    dataset = Dataset.from_dict({"col1": [], "col2": []})
+
+    # Should not raise any exception and return None
+    result = validate_no_duplicates(dataset)
+    assert result is None

--- a/tests/utils/test_datautils.py
+++ b/tests/utils/test_datautils.py
@@ -1,10 +1,10 @@
 # Third Party
-import pytest
 from datasets import Dataset
 
 # First Party
 from sdg_hub.core.utils.datautils import validate_no_duplicates
 from sdg_hub.core.utils.error_handling import FlowValidationError
+import pytest
 
 
 def test_validate_no_duplicates_with_unique_data():


### PR DESCRIPTION
### Adding changes to open issue #350

**Changes**
- Added `validate_no_duplicates()` in utils

**Reason**
- Prevent downstream errors caused by duplicate rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pre-run duplicate detection for input datasets; flows now halt with a clear error if duplicate rows are found and advise deduplication before continuing.
  * Improved validation prevents processing duplicated data earlier in the run.

* **Bug Fixes / Reliability**
  * Enhanced dataset concatenation validation with clearer error reporting when merges fail due to incompatible inputs.

* **Tests**
  * Added unit tests covering duplicate detection and related behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->