### PR TITLE
updated BlockRegistry.all() to BlockRegistry.list_blocks()

### DIFF
--- a/docs/blocks/llm-blocks.md
+++ b/docs/blocks/llm-blocks.md
@@ -34,11 +34,8 @@ The unified chat block that replaces provider-specific implementations with a si
 ### Basic Usage
 
 ```python
-from sdg_hub.core.blocks import BlockRegistry
+from sdg_hub.core.blocks import LLMChatBlock
 from datasets import Dataset
-
-# Get the LLM chat block
-LLMChatBlock = BlockRegistry.get_block("LLMChatBlock")
 
 # Configure for OpenAI
 chat_block = LLMChatBlock(

--- a/docs/blocks/overview.md
+++ b/docs/blocks/overview.md
@@ -30,14 +30,15 @@ All blocks inherit from `BaseBlock`, which provides:
 
 ### Standard Configuration
 ```python
-from sdg_hub.core.blocks import BlockRegistry
+# Import the specific block you need
+from sdg_hub.core.blocks import LLMChatBlock
 
 # Every block has these standard fields
-MyBlock = BlockRegistry.get_block("SomeBlockType")
-block = MyBlock(
+block = LLMChatBlock(
     block_name="my_unique_block",     # Required: unique identifier
-    input_cols=["column1", "column2"], # Columns this block needs
-    output_cols=["new_column"],       # Columns this block creates
+    input_cols=["input_text"],        # Column this block needs
+    output_cols=["response"],         # Column this block creates
+    model="openai/gpt-4o",            # Required: provider/model format
     # ... block-specific configuration
 )
 ```
@@ -86,13 +87,13 @@ print(f"Found {len(available_blocks)} blocks")
 
 ### 2. Block Instantiation
 ```python
-# Get a block class by name
-ChatBlock = BlockRegistry.get_block("LLMChatBlock")
+# Import the specific block you need
+from sdg_hub.core.blocks import LLMChatBlock
 
 # Create an instance with configuration
-chat_block = ChatBlock(
+chat_block = LLMChatBlock(
     block_name="question_answerer",
-    llm_config={"model": "gpt-4o"},
+    model="openai/gpt-4o",
     input_cols=["question"],
     output_cols=["answer"],
     prompt_template="Answer this question: {question}"

--- a/docs/development.md
+++ b/docs/development.md
@@ -123,15 +123,16 @@ Create comprehensive tests following this pattern:
 
 import pytest
 from datasets import Dataset
-from sdg_hub.core.blocks import BlockRegistry
 from sdg_hub.core.utils.error_handling import MissingColumnError
+# Import your custom block directly
+from .my_new_block import MyNewBlock
 
 class TestMyNewBlock:
     """Test suite for MyNewBlock."""
     
     def test_basic_functionality(self):
         """Test basic block functionality."""
-        block = BlockRegistry.get_block("MyNewBlock")(
+        block = MyNewBlock(
             block_name="test_block",
             input_cols=["input"],
             output_cols=["output"]
@@ -149,7 +150,7 @@ class TestMyNewBlock:
     def test_configuration_validation(self):
         """Test parameter validation."""
         with pytest.raises(ValueError):
-            BlockRegistry.get_block("MyNewBlock")(
+            MyNewBlock(
                 block_name="bad_config",
                 input_cols=["input"],
                 output_cols=["output"],
@@ -158,7 +159,7 @@ class TestMyNewBlock:
     
     def test_missing_columns(self):
         """Test error handling for missing columns."""
-        block = BlockRegistry.get_block("MyNewBlock")(
+        block = MyNewBlock(
             block_name="test_block",
             input_cols=["missing_column"],
             output_cols=["output"]

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -107,6 +107,11 @@ print(f"🔎 QA Generation Flows: {qa_flows}")
 eval_flows = FlowRegistry.search_flows(tag="evaluation")
 print(f"📊 Evaluation Flows: {eval_flows}")
 
+# List all blocks by categories
+all_blocks = BlockRegistry.list_blocks()
+for category, blocks in all_blocks.items():
+    print(f"Blocks for category {category}: {blocks}")
+
 # Find blocks by category
 llm_blocks = BlockRegistry.search_blocks(category="llm")
 print(f"🧠 LLM Blocks: {llm_blocks}")

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -113,10 +113,10 @@ for category, blocks in all_blocks.items():
     print(f"Blocks for category {category}: {blocks}")
 
 # Find blocks by category
-llm_blocks = BlockRegistry.search_blocks(category="llm")
+llm_blocks = BlockRegistry.get_category_blocks("llm")
 print(f"🧠 LLM Blocks: {llm_blocks}")
 
-transform_blocks = BlockRegistry.search_blocks(category="transform") 
+transform_blocks = BlockRegistry.get_category_blocks("transform") 
 print(f"🔄 Transform Blocks: {transform_blocks}")
 ```
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -108,15 +108,15 @@ eval_flows = FlowRegistry.search_flows(tag="evaluation")
 print(f"📊 Evaluation Flows: {eval_flows}")
 
 # List all blocks by categories
-all_blocks = BlockRegistry.list_blocks()
+all_blocks = BlockRegistry.list_blocks(grouped=True)
 for category, blocks in all_blocks.items():
     print(f"Blocks for category {category}: {blocks}")
 
 # Find blocks by category
-llm_blocks = BlockRegistry.get_category_blocks("llm")
+llm_blocks = BlockRegistry.list_blocks(category="llm")
 print(f"🧠 LLM Blocks: {llm_blocks}")
 
-transform_blocks = BlockRegistry.get_category_blocks("transform") 
+transform_blocks = BlockRegistry.list_blocks(category="transform") 
 print(f"🔄 Transform Blocks: {transform_blocks}")
 ```
 

--- a/src/sdg_hub/core/blocks/registry.py
+++ b/src/sdg_hub/core/blocks/registry.py
@@ -255,7 +255,7 @@ class BlockRegistry:
         return sorted(cls._categories[category])
 
     @classmethod
-    def all(cls) -> dict[str, list[str]]:
+    def list_blocks(cls) -> dict[str, list[str]]:
         """List all blocks organized by category.
 
         Returns

--- a/src/sdg_hub/core/blocks/registry.py
+++ b/src/sdg_hub/core/blocks/registry.py
@@ -230,8 +230,8 @@ class BlockRegistry:
         return sorted(cls._categories.keys())
 
     @classmethod
-    def get_category_blocks(cls, category: str) -> list[str]:
-        """Get all blocks in a specific category.
+    def _get_category_blocks(cls, category: str) -> list[str]:
+        """Get all blocks in a specific category (private method).
 
         Parameters
         ----------
@@ -257,17 +257,56 @@ class BlockRegistry:
         return sorted(cls._categories[category])
 
     @classmethod
-    def list_blocks(cls) -> dict[str, list[str]]:
-        """List all blocks organized by category.
+    def list_blocks(
+        cls,
+        category: Optional[str] = None,
+        *,
+        grouped: bool = False,
+        include_deprecated: bool = True,
+    ) -> list[str] | dict[str, list[str]]:
+        """
+        List registered blocks, optionally filtered by category.
+
+        Args:
+            category: If provided, return only blocks in this category.
+            grouped: If True (and category is None), return a dict
+                    mapping categories to lists of blocks.
+            include_deprecated: If True, return deprecated blocks.
 
         Returns
         -------
-        Dict[str, List[str]]
-            Dictionary mapping categories to lists of block names.
+        List[str] | Dict[str, List[str]]
+            If grouped is False, returns a list of block names.
+            If grouped is True, returns a dict mapping categories to lists of block names.
         """
-        return {
-            category: sorted(blocks) for category, blocks in cls._categories.items()
-        }
+
+        def filter_deprecated(block_names: list[str]) -> list[str]:
+            if include_deprecated:
+                return block_names
+            return [
+                name
+                for name in block_names
+                if not cls._metadata[name].deprecated
+            ]
+
+        if category:
+            block_names = cls._get_category_blocks(category)
+            return filter_deprecated(block_names)
+
+        if grouped:
+            result = {}
+            for cat, blocks in cls._categories.items():
+                filtered = filter_deprecated(sorted(blocks))
+                if filtered:
+                    result[cat] = filtered
+            return result
+
+        # Flat list of all block names (across all categories)
+        all_block_names = []
+        for blocks in cls._categories.values():
+            all_block_names.extend(blocks)
+        filtered = filter_deprecated(sorted(all_block_names))
+        return filtered
 
     @classmethod
     def discover_blocks(cls) -> None:

--- a/src/sdg_hub/core/blocks/registry.py
+++ b/src/sdg_hub/core/blocks/registry.py
@@ -164,8 +164,10 @@ class BlockRegistry:
                 ) from exc
 
     @classmethod
-    def get(cls, block_name: str) -> type:
-        """Get a block class with enhanced error handling.
+    def _get(cls, block_name: str) -> type:
+        """Internal method to get a block class with enhanced error handling.
+
+        This is a private method used by the framework internals (Flow system).
 
         Parameters
         ----------
@@ -228,7 +230,7 @@ class BlockRegistry:
         return sorted(cls._categories.keys())
 
     @classmethod
-    def category(cls, category: str) -> list[str]:
+    def get_category_blocks(cls, category: str) -> list[str]:
         """Get all blocks in a specific category.
 
         Parameters

--- a/src/sdg_hub/core/blocks/registry.py
+++ b/src/sdg_hub/core/blocks/registry.py
@@ -283,11 +283,7 @@ class BlockRegistry:
         def filter_deprecated(block_names: list[str]) -> list[str]:
             if include_deprecated:
                 return block_names
-            return [
-                name
-                for name in block_names
-                if not cls._metadata[name].deprecated
-            ]
+            return [name for name in block_names if not cls._metadata[name].deprecated]
 
         if category:
             block_names = cls._get_category_blocks(category)

--- a/src/sdg_hub/core/flow/base.py
+++ b/src/sdg_hub/core/flow/base.py
@@ -309,7 +309,7 @@ class Flow(BaseModel):
             block_class = BlockRegistry.get(block_type_name)
         except KeyError as exc:
             # Get all available blocks from all categories
-            all_blocks = BlockRegistry.all()
+            all_blocks = BlockRegistry.list_blocks()
             available_blocks = ", ".join(
                 [block for blocks in all_blocks.values() for block in blocks]
             )

--- a/src/sdg_hub/core/flow/base.py
+++ b/src/sdg_hub/core/flow/base.py
@@ -306,7 +306,7 @@ class Flow(BaseModel):
 
         # Get block class from registry
         try:
-            block_class = BlockRegistry.get(block_type_name)
+            block_class = BlockRegistry._get(block_type_name)
         except KeyError as exc:
             # Get all available blocks from all categories
             all_blocks = BlockRegistry.list_blocks()

--- a/tests/blocks/evaluation/test_evaluate_faithfulness_block.py
+++ b/tests/blocks/evaluation/test_evaluate_faithfulness_block.py
@@ -69,7 +69,7 @@ class TestEvaluateFaithfulnessBlock:
         assert block_class == EvaluateFaithfulnessBlock
 
         # Check category
-        eval_blocks = BlockRegistry.get_category_blocks("evaluation")
+        eval_blocks = BlockRegistry.list_blocks(category="evaluation")
         assert "EvaluateFaithfulnessBlock" in eval_blocks
 
     def test_init_with_valid_params(self, test_yaml_config):

--- a/tests/blocks/evaluation/test_evaluate_faithfulness_block.py
+++ b/tests/blocks/evaluation/test_evaluate_faithfulness_block.py
@@ -65,11 +65,11 @@ class TestEvaluateFaithfulnessBlock:
 
     def test_block_registry(self):
         """Test that EvaluateFaithfulnessBlock is properly registered."""
-        block_class = BlockRegistry.get("EvaluateFaithfulnessBlock")
+        block_class = BlockRegistry._get("EvaluateFaithfulnessBlock")
         assert block_class == EvaluateFaithfulnessBlock
 
         # Check category
-        eval_blocks = BlockRegistry.category("evaluation")
+        eval_blocks = BlockRegistry.get_category_blocks("evaluation")
         assert "EvaluateFaithfulnessBlock" in eval_blocks
 
     def test_init_with_valid_params(self, test_yaml_config):

--- a/tests/blocks/evaluation/test_evaluate_relevancy_block.py
+++ b/tests/blocks/evaluation/test_evaluate_relevancy_block.py
@@ -69,7 +69,7 @@ class TestEvaluateRelevancyBlock:
         assert block_class == EvaluateRelevancyBlock
 
         # Check category
-        eval_blocks = BlockRegistry.get_category_blocks("evaluation")
+        eval_blocks = BlockRegistry.list_blocks(category="evaluation")
         assert "EvaluateRelevancyBlock" in eval_blocks
 
     def test_init_with_valid_params(self, test_yaml_config):

--- a/tests/blocks/evaluation/test_evaluate_relevancy_block.py
+++ b/tests/blocks/evaluation/test_evaluate_relevancy_block.py
@@ -65,11 +65,11 @@ class TestEvaluateRelevancyBlock:
 
     def test_block_registry(self):
         """Test that EvaluateRelevancyBlock is properly registered."""
-        block_class = BlockRegistry.get("EvaluateRelevancyBlock")
+        block_class = BlockRegistry._get("EvaluateRelevancyBlock")
         assert block_class == EvaluateRelevancyBlock
 
         # Check category
-        eval_blocks = BlockRegistry.category("evaluation")
+        eval_blocks = BlockRegistry.get_category_blocks("evaluation")
         assert "EvaluateRelevancyBlock" in eval_blocks
 
     def test_init_with_valid_params(self, test_yaml_config):

--- a/tests/blocks/evaluation/test_verify_question_block.py
+++ b/tests/blocks/evaluation/test_verify_question_block.py
@@ -61,7 +61,7 @@ class TestVerifyQuestionBlock:
         assert block_class == VerifyQuestionBlock
 
         # Check category
-        eval_blocks = BlockRegistry.get_category_blocks("evaluation")
+        eval_blocks = BlockRegistry.list_blocks(category="evaluation")
         assert "VerifyQuestionBlock" in eval_blocks
 
     def test_init_with_valid_params(self, test_yaml_config):

--- a/tests/blocks/evaluation/test_verify_question_block.py
+++ b/tests/blocks/evaluation/test_verify_question_block.py
@@ -57,11 +57,11 @@ class TestVerifyQuestionBlock:
 
     def test_block_registry(self):
         """Test that VerifyQuestionBlock is properly registered."""
-        block_class = BlockRegistry.get("VerifyQuestionBlock")
+        block_class = BlockRegistry._get("VerifyQuestionBlock")
         assert block_class == VerifyQuestionBlock
 
         # Check category
-        eval_blocks = BlockRegistry.category("evaluation")
+        eval_blocks = BlockRegistry.get_category_blocks("evaluation")
         assert "VerifyQuestionBlock" in eval_blocks
 
     def test_init_with_valid_params(self, test_yaml_config):

--- a/tests/blocks/test_registry.py
+++ b/tests/blocks/test_registry.py
@@ -282,7 +282,7 @@ class TestBlockRegistry:
             def generate(self, samples: Dataset, **kwargs) -> Dataset:
                 return samples
 
-        blocks = BlockRegistry.all()
+        blocks = BlockRegistry.list_blocks()
         expected = {"category1": ["Block1", "Block2"], "category2": ["Block3"]}
         assert blocks == expected
 

--- a/tests/blocks/test_registry.py
+++ b/tests/blocks/test_registry.py
@@ -354,7 +354,9 @@ class TestBlockRegistry:
             def generate(self, samples: Dataset, **kwargs) -> Dataset:
                 return samples
 
-        @BlockRegistry.register("DeprecatedBlock", "test", "A deprecated block", deprecated=True)
+        @BlockRegistry.register(
+            "DeprecatedBlock", "test", "A deprecated block", deprecated=True
+        )
         class DeprecatedBlock(BaseBlock):
             def generate(self, samples: Dataset, **kwargs) -> Dataset:
                 return samples
@@ -382,7 +384,9 @@ class TestBlockRegistry:
             def generate(self, samples: Dataset, **kwargs) -> Dataset:
                 return samples
 
-        @BlockRegistry.register("DeprecatedBlock", "test", "A deprecated block", deprecated=True)
+        @BlockRegistry.register(
+            "DeprecatedBlock", "test", "A deprecated block", deprecated=True
+        )
         class DeprecatedBlock(BaseBlock):
             def generate(self, samples: Dataset, **kwargs) -> Dataset:
                 return samples
@@ -397,7 +401,9 @@ class TestBlockRegistry:
         assert test_blocks_with_deprecated == ["ActiveBlock", "DeprecatedBlock"]
 
         # Category with deprecated excluded
-        test_blocks_without_deprecated = BlockRegistry.list_blocks(category="test", include_deprecated=False)
+        test_blocks_without_deprecated = BlockRegistry.list_blocks(
+            category="test", include_deprecated=False
+        )
         assert test_blocks_without_deprecated == ["ActiveBlock"]
 
     def test_list_blocks_grouped_with_deprecated(self):
@@ -408,12 +414,19 @@ class TestBlockRegistry:
             def generate(self, samples: Dataset, **kwargs) -> Dataset:
                 return samples
 
-        @BlockRegistry.register("DeprecatedBlock", "test", "A deprecated block", deprecated=True)
+        @BlockRegistry.register(
+            "DeprecatedBlock", "test", "A deprecated block", deprecated=True
+        )
         class DeprecatedBlock(BaseBlock):
             def generate(self, samples: Dataset, **kwargs) -> Dataset:
                 return samples
 
-        @BlockRegistry.register("OnlyDeprecatedBlock", "deprecated_category", "Only deprecated", deprecated=True)
+        @BlockRegistry.register(
+            "OnlyDeprecatedBlock",
+            "deprecated_category",
+            "Only deprecated",
+            deprecated=True,
+        )
         class OnlyDeprecatedBlock(BaseBlock):
             def generate(self, samples: Dataset, **kwargs) -> Dataset:
                 return samples
@@ -422,12 +435,14 @@ class TestBlockRegistry:
         grouped_with_deprecated = BlockRegistry.list_blocks(grouped=True)
         expected_with = {
             "test": ["ActiveBlock", "DeprecatedBlock"],
-            "deprecated_category": ["OnlyDeprecatedBlock"]
+            "deprecated_category": ["OnlyDeprecatedBlock"],
         }
         assert grouped_with_deprecated == expected_with
 
         # Grouped with deprecated excluded
-        grouped_without_deprecated = BlockRegistry.list_blocks(grouped=True, include_deprecated=False)
+        grouped_without_deprecated = BlockRegistry.list_blocks(
+            grouped=True, include_deprecated=False
+        )
         expected_without = {
             "test": ["ActiveBlock"]
             # Note: deprecated_category should be omitted since it has no non-deprecated blocks
@@ -436,19 +451,19 @@ class TestBlockRegistry:
 
     def test_private_get_category_blocks_not_accessible(self):
         """Test that _get_category_blocks is private and not part of public API."""
-        
+
         @BlockRegistry.register("TestBlock", "test")
         class TestBlock(BaseBlock):
             def generate(self, samples: Dataset, **kwargs) -> Dataset:
                 return samples
 
         # The private method should exist but not be part of public API
-        assert hasattr(BlockRegistry, '_get_category_blocks')
-        
+        assert hasattr(BlockRegistry, "_get_category_blocks")
+
         # It should work when called directly (for internal use)
         private_result = BlockRegistry._get_category_blocks("test")
         assert private_result == ["TestBlock"]
-        
+
         # But the public API should use list_blocks instead
         public_result = BlockRegistry.list_blocks(category="test")
         assert public_result == private_result

--- a/tests/blocks/test_registry.py
+++ b/tests/blocks/test_registry.py
@@ -235,7 +235,7 @@ class TestBlockRegistry:
         assert categories == ["category1", "category2"]
 
     def test_get_blocks_by_category(self):
-        """Test getting blocks by category."""
+        """Test getting blocks by category using list_blocks."""
 
         @BlockRegistry.register("Block1", "test")
         class Block1(BaseBlock):
@@ -252,20 +252,20 @@ class TestBlockRegistry:
             def generate(self, samples: Dataset, **kwargs) -> Dataset:
                 return samples
 
-        test_blocks = BlockRegistry.get_category_blocks("test")
+        test_blocks = BlockRegistry.list_blocks(category="test")
         assert test_blocks == ["Block1", "Block2"]
 
     def test_get_blocks_by_category_not_found(self):
-        """Test error when category not found."""
+        """Test error when category not found using list_blocks."""
         with pytest.raises(KeyError) as exc_info:
-            BlockRegistry.get_category_blocks("NonExistentCategory")
+            BlockRegistry.list_blocks(category="NonExistentCategory")
 
         error_msg = str(exc_info.value)
         assert "NonExistentCategory" in error_msg
         assert "not found" in error_msg
 
-    def test_list_blocks(self):
-        """Test listing all blocks organized by category."""
+    def test_list_blocks_flat(self):
+        """Test listing all blocks as a flat list (default behavior)."""
 
         @BlockRegistry.register("Block1", "category1")
         class Block1(BaseBlock):
@@ -283,8 +283,175 @@ class TestBlockRegistry:
                 return samples
 
         blocks = BlockRegistry.list_blocks()
+        expected = ["Block1", "Block2", "Block3"]
+        assert blocks == expected
+        assert isinstance(blocks, list)
+
+    def test_list_blocks_grouped(self):
+        """Test listing all blocks organized by category."""
+
+        @BlockRegistry.register("Block1", "category1")
+        class Block1(BaseBlock):
+            def generate(self, samples: Dataset, **kwargs) -> Dataset:
+                return samples
+
+        @BlockRegistry.register("Block2", "category1")
+        class Block2(BaseBlock):
+            def generate(self, samples: Dataset, **kwargs) -> Dataset:
+                return samples
+
+        @BlockRegistry.register("Block3", "category2")
+        class Block3(BaseBlock):
+            def generate(self, samples: Dataset, **kwargs) -> Dataset:
+                return samples
+
+        blocks = BlockRegistry.list_blocks(grouped=True)
         expected = {"category1": ["Block1", "Block2"], "category2": ["Block3"]}
         assert blocks == expected
+        assert isinstance(blocks, dict)
+
+    def test_list_blocks_by_category(self):
+        """Test listing blocks filtered by category."""
+
+        @BlockRegistry.register("Block1", "category1")
+        class Block1(BaseBlock):
+            def generate(self, samples: Dataset, **kwargs) -> Dataset:
+                return samples
+
+        @BlockRegistry.register("Block2", "category1")
+        class Block2(BaseBlock):
+            def generate(self, samples: Dataset, **kwargs) -> Dataset:
+                return samples
+
+        @BlockRegistry.register("Block3", "category2")
+        class Block3(BaseBlock):
+            def generate(self, samples: Dataset, **kwargs) -> Dataset:
+                return samples
+
+        # Test specific category
+        category1_blocks = BlockRegistry.list_blocks(category="category1")
+        assert category1_blocks == ["Block1", "Block2"]
+        assert isinstance(category1_blocks, list)
+
+        category2_blocks = BlockRegistry.list_blocks(category="category2")
+        assert category2_blocks == ["Block3"]
+        assert isinstance(category2_blocks, list)
+
+    def test_list_blocks_category_not_found(self):
+        """Test error when filtering by non-existent category."""
+        with pytest.raises(KeyError) as exc_info:
+            BlockRegistry.list_blocks(category="NonExistentCategory")
+
+        error_msg = str(exc_info.value)
+        assert "NonExistentCategory" in error_msg
+        assert "not found" in error_msg
+
+    def test_list_blocks_include_deprecated(self):
+        """Test listing blocks with deprecated filtering."""
+
+        @BlockRegistry.register("ActiveBlock", "test", "An active block")
+        class ActiveBlock(BaseBlock):
+            def generate(self, samples: Dataset, **kwargs) -> Dataset:
+                return samples
+
+        @BlockRegistry.register("DeprecatedBlock", "test", "A deprecated block", deprecated=True)
+        class DeprecatedBlock(BaseBlock):
+            def generate(self, samples: Dataset, **kwargs) -> Dataset:
+                return samples
+
+        # Default behavior includes deprecated blocks
+        all_blocks = BlockRegistry.list_blocks()
+        assert "ActiveBlock" in all_blocks
+        assert "DeprecatedBlock" in all_blocks
+
+        # Explicitly include deprecated
+        with_deprecated = BlockRegistry.list_blocks(include_deprecated=True)
+        assert "ActiveBlock" in with_deprecated
+        assert "DeprecatedBlock" in with_deprecated
+
+        # Exclude deprecated blocks
+        without_deprecated = BlockRegistry.list_blocks(include_deprecated=False)
+        assert "ActiveBlock" in without_deprecated
+        assert "DeprecatedBlock" not in without_deprecated
+
+    def test_list_blocks_category_with_deprecated(self):
+        """Test listing blocks by category with deprecated filtering."""
+
+        @BlockRegistry.register("ActiveBlock", "test", "An active block")
+        class ActiveBlock(BaseBlock):
+            def generate(self, samples: Dataset, **kwargs) -> Dataset:
+                return samples
+
+        @BlockRegistry.register("DeprecatedBlock", "test", "A deprecated block", deprecated=True)
+        class DeprecatedBlock(BaseBlock):
+            def generate(self, samples: Dataset, **kwargs) -> Dataset:
+                return samples
+
+        @BlockRegistry.register("OtherBlock", "other", "Another block")
+        class OtherBlock(BaseBlock):
+            def generate(self, samples: Dataset, **kwargs) -> Dataset:
+                return samples
+
+        # Category with deprecated included (default)
+        test_blocks_with_deprecated = BlockRegistry.list_blocks(category="test")
+        assert test_blocks_with_deprecated == ["ActiveBlock", "DeprecatedBlock"]
+
+        # Category with deprecated excluded
+        test_blocks_without_deprecated = BlockRegistry.list_blocks(category="test", include_deprecated=False)
+        assert test_blocks_without_deprecated == ["ActiveBlock"]
+
+    def test_list_blocks_grouped_with_deprecated(self):
+        """Test listing blocks grouped by category with deprecated filtering."""
+
+        @BlockRegistry.register("ActiveBlock", "test", "An active block")
+        class ActiveBlock(BaseBlock):
+            def generate(self, samples: Dataset, **kwargs) -> Dataset:
+                return samples
+
+        @BlockRegistry.register("DeprecatedBlock", "test", "A deprecated block", deprecated=True)
+        class DeprecatedBlock(BaseBlock):
+            def generate(self, samples: Dataset, **kwargs) -> Dataset:
+                return samples
+
+        @BlockRegistry.register("OnlyDeprecatedBlock", "deprecated_category", "Only deprecated", deprecated=True)
+        class OnlyDeprecatedBlock(BaseBlock):
+            def generate(self, samples: Dataset, **kwargs) -> Dataset:
+                return samples
+
+        # Grouped with deprecated included (default)
+        grouped_with_deprecated = BlockRegistry.list_blocks(grouped=True)
+        expected_with = {
+            "test": ["ActiveBlock", "DeprecatedBlock"],
+            "deprecated_category": ["OnlyDeprecatedBlock"]
+        }
+        assert grouped_with_deprecated == expected_with
+
+        # Grouped with deprecated excluded
+        grouped_without_deprecated = BlockRegistry.list_blocks(grouped=True, include_deprecated=False)
+        expected_without = {
+            "test": ["ActiveBlock"]
+            # Note: deprecated_category should be omitted since it has no non-deprecated blocks
+        }
+        assert grouped_without_deprecated == expected_without
+
+    def test_private_get_category_blocks_not_accessible(self):
+        """Test that _get_category_blocks is private and not part of public API."""
+        
+        @BlockRegistry.register("TestBlock", "test")
+        class TestBlock(BaseBlock):
+            def generate(self, samples: Dataset, **kwargs) -> Dataset:
+                return samples
+
+        # The private method should exist but not be part of public API
+        assert hasattr(BlockRegistry, '_get_category_blocks')
+        
+        # It should work when called directly (for internal use)
+        private_result = BlockRegistry._get_category_blocks("test")
+        assert private_result == ["TestBlock"]
+        
+        # But the public API should use list_blocks instead
+        public_result = BlockRegistry.list_blocks(category="test")
+        assert public_result == private_result
 
     def test_print_blocks_empty_registry(self):
         """Test printing blocks when registry is empty."""
@@ -359,7 +526,7 @@ class TestBlockRegistry:
                 return samples
 
         # Check both blocks are in the same category
-        blocks_in_category = BlockRegistry.get_category_blocks("shared_category")
+        blocks_in_category = BlockRegistry.list_blocks(category="shared_category")
         assert "Block1" in blocks_in_category
         assert "Block2" in blocks_in_category
         assert len(blocks_in_category) == 2

--- a/tests/blocks/test_registry.py
+++ b/tests/blocks/test_registry.py
@@ -169,13 +169,13 @@ class TestBlockRegistry:
             def generate(self, samples: Dataset, **kwargs) -> Dataset:
                 return samples
 
-        retrieved_class = BlockRegistry.get("TestBlock")
+        retrieved_class = BlockRegistry._get("TestBlock")
         assert retrieved_class == TestBlock
 
     def test_get_block_class_not_found(self):
         """Test error when block not found."""
         with pytest.raises(KeyError) as exc_info:
-            BlockRegistry.get("NonExistentBlock")
+            BlockRegistry._get("NonExistentBlock")
 
         error_msg = str(exc_info.value)
         assert "NonExistentBlock" in error_msg
@@ -190,7 +190,7 @@ class TestBlockRegistry:
                 return samples
 
         with pytest.raises(KeyError) as exc_info:
-            BlockRegistry.get("TestBloc")  # Missing 'k'
+            BlockRegistry._get("TestBloc")  # Missing 'k'
 
         error_msg = str(exc_info.value)
         assert "Did you mean: TestBlock" in error_msg
@@ -209,7 +209,7 @@ class TestBlockRegistry:
             # Clear previous calls from registration
             mock_logger.reset_mock()
 
-            retrieved_class = BlockRegistry.get("OldBlock")
+            retrieved_class = BlockRegistry._get("OldBlock")
             assert retrieved_class == OldBlock
 
             # Check deprecation warning was logged
@@ -252,13 +252,13 @@ class TestBlockRegistry:
             def generate(self, samples: Dataset, **kwargs) -> Dataset:
                 return samples
 
-        test_blocks = BlockRegistry.category("test")
+        test_blocks = BlockRegistry.get_category_blocks("test")
         assert test_blocks == ["Block1", "Block2"]
 
     def test_get_blocks_by_category_not_found(self):
         """Test error when category not found."""
         with pytest.raises(KeyError) as exc_info:
-            BlockRegistry.category("NonExistentCategory")
+            BlockRegistry.get_category_blocks("NonExistentCategory")
 
         error_msg = str(exc_info.value)
         assert "NonExistentCategory" in error_msg
@@ -359,7 +359,7 @@ class TestBlockRegistry:
                 return samples
 
         # Check both blocks are in the same category
-        blocks_in_category = BlockRegistry.category("shared_category")
+        blocks_in_category = BlockRegistry.get_category_blocks("shared_category")
         assert "Block1" in blocks_in_category
         assert "Block2" in blocks_in_category
         assert len(blocks_in_category) == 2
@@ -373,7 +373,7 @@ class TestBlockRegistry:
                 return samples
 
         with pytest.raises(KeyError) as exc_info:
-            BlockRegistry.get("NonExistentBlock")
+            BlockRegistry._get("NonExistentBlock")
 
         error_msg = str(exc_info.value)
         assert "Available blocks: ExistingBlock" in error_msg

--- a/tests/flow/conftest.py
+++ b/tests/flow/conftest.py
@@ -188,7 +188,7 @@ def mock_block_registry():
             mock_class.return_value = mock_instance
             return mock_class
 
-        mock_registry.get.side_effect = mock_get
+        mock_registry._get.side_effect = mock_get
         mock_registry.list_blocks.return_value = ["LLMChatBlock", "MockBlock"]
 
         yield mock_registry

--- a/tests/flow/test_base.py
+++ b/tests/flow/test_base.py
@@ -1121,3 +1121,48 @@ class TestFlow:
         with open(checkpoint_files[0], "r") as f:
             checkpoint_data = json.loads(f.readline())
             assert "final" in checkpoint_data
+
+    def test_create_block_from_config_block_not_found(self):
+        """Test _create_block_from_config when block type is not found in registry."""
+        # Standard
+        from pathlib import Path
+        
+        # Mock BlockRegistry to simulate available blocks
+        with patch("sdg_hub.core.flow.base.BlockRegistry.get") as mock_get, \
+             patch("sdg_hub.core.flow.base.BlockRegistry.list_blocks") as mock_list_blocks:
+            
+            # Configure mocks
+            mock_get.side_effect = KeyError("Block 'nonexistent_block' not found")
+            mock_list_blocks.return_value = {
+                "llm": ["llm_chat", "prompt_builder"],
+                "transform": ["text_concat", "rename_columns"],
+                "filtering": ["column_value_filter"]
+            }
+            
+            # Create block config with nonexistent block type
+            block_config = {
+                "block_type": "nonexistent_block",
+                "block_config": {"param": "value"}
+            }
+            yaml_dir = Path(self.temp_dir)
+            
+            # Test that FlowValidationError is raised with helpful message
+            with pytest.raises(FlowValidationError) as exc_info:
+                Flow._create_block_from_config(block_config, yaml_dir)
+            
+            error_message = str(exc_info.value)
+            
+            # Verify error message contains expected information
+            assert "Block type 'nonexistent_block' not found in registry" in error_message
+            assert "Available blocks:" in error_message
+            
+            # Verify all available blocks are listed in the error message
+            assert "llm_chat" in error_message
+            assert "prompt_builder" in error_message
+            assert "text_concat" in error_message
+            assert "rename_columns" in error_message
+            assert "column_value_filter" in error_message
+            
+            # Verify the blocks are flattened from all categories
+            mock_list_blocks.assert_called_once()
+            mock_get.assert_called_once_with("nonexistent_block")

--- a/tests/flow/test_base.py
+++ b/tests/flow/test_base.py
@@ -1126,43 +1126,48 @@ class TestFlow:
         """Test _create_block_from_config when block type is not found in registry."""
         # Standard
         from pathlib import Path
-        
+
         # Mock BlockRegistry to simulate available blocks
-        with patch("sdg_hub.core.flow.base.BlockRegistry.get") as mock_get, \
-             patch("sdg_hub.core.flow.base.BlockRegistry.list_blocks") as mock_list_blocks:
-            
+        with (
+            patch("sdg_hub.core.flow.base.BlockRegistry.get") as mock_get,
+            patch(
+                "sdg_hub.core.flow.base.BlockRegistry.list_blocks"
+            ) as mock_list_blocks,
+        ):
             # Configure mocks
             mock_get.side_effect = KeyError("Block 'nonexistent_block' not found")
             mock_list_blocks.return_value = {
                 "llm": ["llm_chat", "prompt_builder"],
                 "transform": ["text_concat", "rename_columns"],
-                "filtering": ["column_value_filter"]
+                "filtering": ["column_value_filter"],
             }
-            
+
             # Create block config with nonexistent block type
             block_config = {
                 "block_type": "nonexistent_block",
-                "block_config": {"param": "value"}
+                "block_config": {"param": "value"},
             }
             yaml_dir = Path(self.temp_dir)
-            
+
             # Test that FlowValidationError is raised with helpful message
             with pytest.raises(FlowValidationError) as exc_info:
                 Flow._create_block_from_config(block_config, yaml_dir)
-            
+
             error_message = str(exc_info.value)
-            
+
             # Verify error message contains expected information
-            assert "Block type 'nonexistent_block' not found in registry" in error_message
+            assert (
+                "Block type 'nonexistent_block' not found in registry" in error_message
+            )
             assert "Available blocks:" in error_message
-            
+
             # Verify all available blocks are listed in the error message
             assert "llm_chat" in error_message
             assert "prompt_builder" in error_message
             assert "text_concat" in error_message
             assert "rename_columns" in error_message
             assert "column_value_filter" in error_message
-            
+
             # Verify the blocks are flattened from all categories
             mock_list_blocks.assert_called_once()
             mock_get.assert_called_once_with("nonexistent_block")

--- a/tests/flow/test_base.py
+++ b/tests/flow/test_base.py
@@ -1129,7 +1129,7 @@ class TestFlow:
 
         # Mock BlockRegistry to simulate available blocks
         with (
-            patch("sdg_hub.core.flow.base.BlockRegistry.get") as mock_get,
+            patch("sdg_hub.core.flow.base.BlockRegistry._get") as mock_get,
             patch(
                 "sdg_hub.core.flow.base.BlockRegistry.list_blocks"
             ) as mock_list_blocks,

--- a/tests/flow/test_base.py
+++ b/tests/flow/test_base.py
@@ -160,7 +160,7 @@ class TestFlow:
             yaml.dump(flow_config, f)
 
         # Mock the block creation
-        with patch("sdg_hub.core.flow.base.BlockRegistry.get") as mock_get:
+        with patch("sdg_hub.core.flow.base.BlockRegistry._get") as mock_get:
             mock_block_class = Mock()
             mock_block_instance = self.create_mock_block("test_block")
             mock_block_class.return_value = mock_block_instance
@@ -216,7 +216,7 @@ class TestFlow:
             yaml.dump(flow_config, f)
 
         # Mock the block creation
-        with patch("sdg_hub.core.flow.base.BlockRegistry.get") as mock_get:
+        with patch("sdg_hub.core.flow.base.BlockRegistry._get") as mock_get:
             mock_block_class = Mock()
             mock_block_instance = self.create_mock_block("test_block")
             mock_block_class.return_value = mock_block_instance

--- a/tests/flow/test_integration.py
+++ b/tests/flow/test_integration.py
@@ -85,7 +85,7 @@ class TestFlowIntegration:
                 mock_class.return_value = mock_instance
                 return mock_class
 
-            mock_registry.get.side_effect = mock_get
+            mock_registry._get.side_effect = mock_get
 
             # Load the flow
             flow = Flow.from_yaml(str(yaml_path))
@@ -386,7 +386,7 @@ class TestFlowIntegration:
                 mock_class.return_value = mock_instance
                 return mock_class
 
-            mock_registry.get.side_effect = mock_get
+            mock_registry._get.side_effect = mock_get
 
             # Load the flow
             flow = Flow.from_yaml(str(yaml_path))


### PR DESCRIPTION
This PR refactors the BlockRegistry.all() method to BlockRegistry.list_blocks() for better naming convention, enhanced user experience and compatibility with the API.

Addresses issue #323
 
### Changes Made

#### API
1. `src/sdg_hub/core/blocks/registry.py`  - Refactored "all()" method of BlockRegistry to "list_blocks()".
2. `src/sdg_hub/core/flow/base.py` - Update usage from .all() to list_blocks()

#### Documentation
1. `docs/quick-start.md` - Add example usage to quick-start.md

### Usage Example

```python

from sdg_hub.core.blocks.registry import BlockRegistry

all_blocks = BlockRegistry.list_blocks()
for category, blocks in all_blocks.items():
    print(f"Blocks for category {category}: {blocks}")

```

### Test

1. `tests/blocks/test_registry.py` - verify the renamed method works as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Quick Start and docs updated to show grouped block listings by category and to prefer direct class instantiation in examples instead of registry-based retrieval.

* **Refactor**
  * Block listing/enumeration API consolidated into a single unified listing interface; examples and code updated to use the new, consistent listing behavior (including category/grouped views and deprecation filtering).

* **Tests**
  * Tests updated for the new listing interface and added checks that missing-block errors include an "Available blocks" listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->