### PR TITLE
Fix #363 timeout not respected

### DIFF
--- a/src/sdg_hub/core/blocks/llm/config.py
+++ b/src/sdg_hub/core/blocks/llm/config.py
@@ -240,6 +240,7 @@ class LLMConfig:
             "logprobs",
             "top_logprobs",
             "user",
+            "timeout",
         ]:
             value = getattr(self, param)
             if value is not None:

--- a/tests/blocks/llm/test_llm_chat_block.py
+++ b/tests/blocks/llm/test_llm_chat_block.py
@@ -148,6 +148,7 @@ class TestLLMConfig:
             max_tokens=100,
             seed=42,
             extra_headers={"x-custom": "value"},
+            timeout=120,
         )
 
         kwargs = config.get_generation_kwargs()
@@ -155,6 +156,7 @@ class TestLLMConfig:
         assert kwargs["max_tokens"] == 100
         assert kwargs["seed"] == 42
         assert kwargs["extra_headers"] == {"x-custom": "value"}
+        assert kwargs["timeout"] == 120
 
     def test_merge_overrides(self):
         """Test configuration merging with overrides."""


### PR DESCRIPTION
Closes [#363]

- `tests/blocks/llm/test_llm_chat_block.py`: Added check for timeout addition to kwargs
- `src/sdg_hub/core/blocks/llm/config.py`: Added fix

---

Tested as below:
Initial Test Run:
```bash
pytest tests/blocks/llm/test_llm_chat_block.py
```
Output:
```
41 passed
```

---

After updating tests:

```bash
pytest tests/blocks/llm/test_llm_chat_block.py
```
Output:
```
=================================================================================================================================== test session starts ====================================================================================================================================
platform darwin -- Python 3.12.10, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/rawhad/1_Projects/sdg_hub
configfile: pyproject.toml
plugins: html-4.1.1, asyncio-1.1.0, metadata-3.1.1, anyio-4.10.0, cov-6.2.1
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 41 items

tests/blocks/llm/test_llm_chat_block.py ......F..................................                                                                                                                                                                                                    [100%]

========================================================================================================================================= FAILURES =========================================================================================================================================
___________________________________________________________________________________________________________________________ TestLLMConfig.test_generation_kwargs ___________________________________________________________________________________________________________________________

self = <test_llm_chat_block.TestLLMConfig object at 0x10fb23170>

    def test_generation_kwargs(self):
        """Test generation kwargs extraction."""
        config = LLMConfig(
            model="openai/gpt-4",
            temperature=0.7,
            max_tokens=100,
            seed=42,
            extra_headers={"x-custom": "value"},
            timeout=120,
        )

        kwargs = config.get_generation_kwargs()
        assert kwargs["temperature"] == 0.7
        assert kwargs["max_tokens"] == 100
        assert kwargs["seed"] == 42
        assert kwargs["extra_headers"] == {"x-custom": "value"}
>       assert kwargs["timeout"] == 120
               ^^^^^^^^^^^^^^^^^
E       KeyError: 'timeout'

tests/blocks/llm/test_llm_chat_block.py:159: KeyError
================================================================================================================================= short test summary info ==================================================================================================================================
FAILED tests/blocks/llm/test_llm_chat_block.py::TestLLMConfig::test_generation_kwargs - KeyError: 'timeout'
============================================================================================================================== 1 failed, 40 passed in 21.69s ===============================================================================================================================
```

---

Test results after adding fix to `src/sdg_hub/core/blocks/llm/config.py`
Output:
```
41 Passed
```

---

A simple script to test:
```python
# play.py
import os
from datasets import Dataset
from sdg_hub.core.blocks.llm.llm_chat_block import LLMChatBlock

def reproduce_timeout_issue():
  # Make sure you have OPENAI_API_KEY set
  if not os.getenv("OPENAI_API_KEY"):
    print("Please set OPENAI_API_KEY environment variable")
    return
  
  # Create block with very short timeout
  block = LLMChatBlock(
    block_name="timeout_test",
    input_cols="messages", 
    output_cols="response",
    model="openai/gpt-4.1",
    timeout=2.0,  # 2 second timeout
    temperature=0.7
  )
  
  # Create a request that will take longer than 2 seconds
  messages = [[
    {"role": "system", "content": "You are a helpful assistant."},
    {"role": "user", "content": "Write a very detailed 1500-word essay about quantum computing, including mathematical formulations, practical applications, and future implications. Be extremely thorough and comprehensive."}
  ]]
  
  dataset = Dataset.from_dict({"messages": messages})
  
  print(f"Block timeout configured as: {block.timeout}")
  print(f"Client manager timeout: {block.client_manager.config.timeout}")
  
  try:
    result = block.generate(dataset)
    print("Unexpected success!")
  except Exception as e:
    print(f"Error: {e}")
    print(f"Error type: {type(e)}")
    # Check if the error message shows the wrong timeout value
    if "timeout" in str(e).lower():
      print("Found timeout in error - check if value matches configured timeout")

if __name__ == "__main__":
  reproduce_timeout_issue()
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added configurable timeout for AI generation requests, defaulting to 120 seconds. The timeout is automatically included in requests and can be adjusted to fit performance needs.
- Tests
  - Extended tests to validate the default timeout and its propagation into generation parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->