### PR TITLE
Add dataset schema discovery functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ A modular Python framework for building synthetic data generation pipelines usin
 
 **📊 Rich Monitoring** - Detailed logging with progress bars and execution summaries.
 
+**📋 Dataset Schema Discovery** - Instantly discover required data formats. Get empty datasets with correct schema for easy validation and data preparation.
+
 **🧩 Easily Extensible** - Create custom blocks with simple inheritance. Rich logging and monitoring built-in.
 
 
@@ -108,22 +110,46 @@ flow.set_model_config(
     api_key="your_key",
 )
 ```
-#### Load your dataset and run the flow
+#### Discover dataset requirements and create your dataset
 ```python
-# Create your dataset with required columns
-dataset = Dataset.from_dict({
-    'document': ['Your document text here...'],
-    'document_outline': ['1. Topic A; 2. Topic B; 3. Topic C'],
-    'domain': ['Computer Science'],
-    'icl_document': ['Example document for in-context learning...'],
-    'icl_query_1': ['Example question 1?'],
-    'icl_response_1': ['Example answer 1'],
-    'icl_query_2': ['Example question 2?'], 
-    'icl_response_2': ['Example answer 2'],
-    'icl_query_3': ['Example question 3?'],
-    'icl_response_3': ['Example answer 3']
+# First, discover what data the flow needs
+# Get an empty dataset with the exact schema needed
+schema_dataset = flow.get_dataset_schema()  # Get empty dataset with correct schema
+print(f"Required columns: {schema_dataset.column_names}")
+print(f"Schema: {schema_dataset.features}")
+
+# Option 1: Add data directly to the schema dataset
+dataset = schema_dataset.add_item({
+    'document': 'Your document text here...',
+    'document_outline': '1. Topic A; 2. Topic B; 3. Topic C',
+    'domain': 'Computer Science',
+    'icl_document': 'Example document for in-context learning...',
+    'icl_query_1': 'Example question 1?',
+    'icl_response_1': 'Example answer 1',
+    'icl_query_2': 'Example question 2?', 
+    'icl_response_2': 'Example answer 2',
+    'icl_query_3': 'Example question 3?',
+    'icl_response_3': 'Example answer 3'
 })
 
+# Option 2: Create your own dataset and validate the schema
+my_dataset = Dataset.from_dict(my_data_dict)
+if my_dataset.features == schema_dataset.features:
+    print("✅ Schema matches - ready to generate!")
+    dataset = my_dataset
+else:
+    print("❌ Schema mismatch - check your columns")
+
+# Option 3: Get raw requirements for detailed inspection
+requirements = flow.get_dataset_requirements()
+if requirements:
+    print(f"Required: {requirements.required_columns}")
+    print(f"Optional: {requirements.optional_columns}")
+    print(f"Min samples: {requirements.min_samples}")
+```
+
+#### Dry Run and Generate
+```python
 # Quick Testing with Dry Run
 dry_result = flow.dry_run(dataset, sample_size=1)
 print(f"Dry run completed in {dry_result['execution_time_seconds']:.2f}s")

--- a/src/sdg_hub/core/flow/base.py
+++ b/src/sdg_hub/core/flow/base.py
@@ -1136,9 +1136,6 @@ class Flow(BaseModel):
 
     def _map_column_type_to_feature(self, col_type: str):
         """Map column type string to HuggingFace feature type."""
-        # Third Party
-        import datasets
-
         # Map common type names to HuggingFace types
         if col_type in ["str", "string", "text"]:
             return datasets.Value("string")

--- a/src/sdg_hub/core/flow/base.py
+++ b/src/sdg_hub/core/flow/base.py
@@ -13,6 +13,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 from rich.tree import Tree
+import datasets
 import yaml
 
 # Local
@@ -24,7 +25,7 @@ from ..utils.logger_config import setup_logger
 from ..utils.path_resolution import resolve_path
 from ..utils.yaml_utils import save_flow_yaml
 from .checkpointer import FlowCheckpointer
-from .metadata import FlowMetadata, FlowParameter
+from .metadata import DatasetRequirements, FlowMetadata, FlowParameter
 from .migration import FlowMigration
 from .validation import FlowValidator
 
@@ -1064,7 +1065,7 @@ class Flow(BaseModel):
             "block_names": [block.block_name for block in self.blocks],
         }
 
-    def get_dataset_requirements(self) -> Optional["DatasetRequirements"]:
+    def get_dataset_requirements(self) -> Optional[DatasetRequirements]:
         """Get the dataset requirements for this flow.
 
         Returns
@@ -1094,52 +1095,50 @@ class Flow(BaseModel):
         --------
         >>> flow = Flow.from_yaml("path/to/flow.yaml")
         >>> schema_dataset = flow.get_dataset_schema()
-        >>> 
+        >>>
         >>> # Add your data
         >>> schema_dataset = schema_dataset.add_item({
         ...     "document": "Your document text",
         ...     "domain": "Computer Science",
         ...     "icl_document": "Example document"
         ... })
-        >>> 
+        >>>
         >>> # Or validate your existing dataset schema
         >>> my_dataset = Dataset.from_dict(my_data)
         >>> if my_dataset.features == schema_dataset.features:
         ...     print("Schema matches!")
         """
-        # Third Party
-        import datasets
-        
+
         requirements = self.get_dataset_requirements()
-        
+
         if requirements is None:
             # Return empty dataset with no schema requirements
             return Dataset.from_dict({})
-            
+
         # Build schema features
         schema_features = {}
-        
+
         # Process required columns
         for col_name in requirements.required_columns:
             col_type = requirements.column_types.get(col_name, "string")
             schema_features[col_name] = self._map_column_type_to_feature(col_type)
-                
+
         # Process optional columns
         for col_name in requirements.optional_columns:
             col_type = requirements.column_types.get(col_name, "string")
             schema_features[col_name] = self._map_column_type_to_feature(col_type)
-        
+
         # Create empty dataset with the correct features
         features = datasets.Features(schema_features)
         empty_data = {col_name: [] for col_name in schema_features.keys()}
-        
+
         return Dataset.from_dict(empty_data, features=features)
 
     def _map_column_type_to_feature(self, col_type: str):
         """Map column type string to HuggingFace feature type."""
         # Third Party
         import datasets
-        
+
         # Map common type names to HuggingFace types
         if col_type in ["str", "string", "text"]:
             return datasets.Value("string")

--- a/src/sdg_hub/core/flow/base.py
+++ b/src/sdg_hub/core/flow/base.py
@@ -1064,6 +1064,95 @@ class Flow(BaseModel):
             "block_names": [block.block_name for block in self.blocks],
         }
 
+    def get_dataset_requirements(self) -> Optional["DatasetRequirements"]:
+        """Get the dataset requirements for this flow.
+
+        Returns
+        -------
+        Optional[DatasetRequirements]
+            Dataset requirements object or None if not defined.
+
+        Examples
+        --------
+        >>> flow = Flow.from_yaml("path/to/flow.yaml")
+        >>> requirements = flow.get_dataset_requirements()
+        >>> if requirements:
+        ...     print(f"Required columns: {requirements.required_columns}")
+        """
+        return self.metadata.dataset_requirements
+
+    def get_dataset_schema(self) -> Dataset:
+        """Get an empty dataset with the correct schema for this flow.
+
+        Returns
+        -------
+        Dataset
+            Empty HuggingFace Dataset with the correct schema/features for this flow.
+            Users can add data to this dataset or use it to validate their own dataset schema.
+
+        Examples
+        --------
+        >>> flow = Flow.from_yaml("path/to/flow.yaml")
+        >>> schema_dataset = flow.get_dataset_schema()
+        >>> 
+        >>> # Add your data
+        >>> schema_dataset = schema_dataset.add_item({
+        ...     "document": "Your document text",
+        ...     "domain": "Computer Science",
+        ...     "icl_document": "Example document"
+        ... })
+        >>> 
+        >>> # Or validate your existing dataset schema
+        >>> my_dataset = Dataset.from_dict(my_data)
+        >>> if my_dataset.features == schema_dataset.features:
+        ...     print("Schema matches!")
+        """
+        # Third Party
+        import datasets
+        
+        requirements = self.get_dataset_requirements()
+        
+        if requirements is None:
+            # Return empty dataset with no schema requirements
+            return Dataset.from_dict({})
+            
+        # Build schema features
+        schema_features = {}
+        
+        # Process required columns
+        for col_name in requirements.required_columns:
+            col_type = requirements.column_types.get(col_name, "string")
+            schema_features[col_name] = self._map_column_type_to_feature(col_type)
+                
+        # Process optional columns
+        for col_name in requirements.optional_columns:
+            col_type = requirements.column_types.get(col_name, "string")
+            schema_features[col_name] = self._map_column_type_to_feature(col_type)
+        
+        # Create empty dataset with the correct features
+        features = datasets.Features(schema_features)
+        empty_data = {col_name: [] for col_name in schema_features.keys()}
+        
+        return Dataset.from_dict(empty_data, features=features)
+
+    def _map_column_type_to_feature(self, col_type: str):
+        """Map column type string to HuggingFace feature type."""
+        # Third Party
+        import datasets
+        
+        # Map common type names to HuggingFace types
+        if col_type in ["str", "string", "text"]:
+            return datasets.Value("string")
+        elif col_type in ["int", "integer"]:
+            return datasets.Value("int64")
+        elif col_type in ["float", "number"]:
+            return datasets.Value("float64")
+        elif col_type in ["bool", "boolean"]:
+            return datasets.Value("bool")
+        else:
+            # Default to string for unknown types
+            return datasets.Value("string")
+
     def print_info(self) -> None:
         """
         Print an interactive summary of the Flow in the console.

--- a/tests/flow/test_dataset_requirements.py
+++ b/tests/flow/test_dataset_requirements.py
@@ -7,13 +7,13 @@ from unittest.mock import Mock, patch
 
 # Third Party
 from datasets import Dataset
-import datasets
-import pytest
-import yaml
 
 # First Party
 from sdg_hub import Flow
 from sdg_hub.core.flow.metadata import DatasetRequirements
+import datasets
+import pytest
+import yaml
 
 
 class TestDatasetRequirements:
@@ -130,7 +130,9 @@ class TestDatasetRequirements:
         }
         assert requirements.description == "Test dataset requirements"
 
-    def test_get_dataset_requirements_without_requirements(self, flow_without_requirements):
+    def test_get_dataset_requirements_without_requirements(
+        self, flow_without_requirements
+    ):
         """Test get_dataset_requirements with flow that has no requirements."""
         requirements = flow_without_requirements.get_dataset_requirements()
 
@@ -175,7 +177,13 @@ class TestDatasetRequirements:
                 "version": "1.0.0",
                 "author": "Test Suite",
                 "dataset_requirements": {
-                    "required_columns": ["text_col", "int_col", "float_col", "bool_col", "unknown_col"],
+                    "required_columns": [
+                        "text_col",
+                        "int_col",
+                        "float_col",
+                        "bool_col",
+                        "unknown_col",
+                    ],
                     "column_types": {
                         "text_col": "string",
                         "int_col": "integer",
@@ -220,7 +228,9 @@ class TestDatasetRequirements:
         assert schema_dataset.features["int_col"].dtype == "int64"
         assert schema_dataset.features["float_col"].dtype == "float64"
         assert schema_dataset.features["bool_col"].dtype == "bool"
-        assert schema_dataset.features["unknown_col"].dtype == "string"  # Unknown types default to string
+        assert (
+            schema_dataset.features["unknown_col"].dtype == "string"
+        )  # Unknown types default to string
 
     def test_get_dataset_schema_alternative_type_names(self, temp_dir, mock_block):
         """Test that alternative type names are correctly mapped."""
@@ -231,7 +241,13 @@ class TestDatasetRequirements:
                 "version": "1.0.0",
                 "author": "Test Suite",
                 "dataset_requirements": {
-                    "required_columns": ["str_col", "text_col", "int_col", "number_col", "bool_col"],
+                    "required_columns": [
+                        "str_col",
+                        "text_col",
+                        "int_col",
+                        "number_col",
+                        "bool_col",
+                    ],
                     "column_types": {
                         "str_col": "str",
                         "text_col": "text",
@@ -278,7 +294,9 @@ class TestDatasetRequirements:
         assert schema_dataset.features["number_col"].dtype == "float64"
         assert schema_dataset.features["bool_col"].dtype == "bool"
 
-    def test_dataset_schema_compatibility_with_huggingface(self, flow_with_requirements):
+    def test_dataset_schema_compatibility_with_huggingface(
+        self, flow_with_requirements
+    ):
         """Test that the schema dataset can be used with HuggingFace datasets."""
         schema_dataset = flow_with_requirements.get_dataset_schema()
 
@@ -286,7 +304,7 @@ class TestDatasetRequirements:
         sample_data = {
             col_name: "sample_value" for col_name in schema_dataset.column_names
         }
-        
+
         populated_dataset = schema_dataset.add_item(sample_data)
 
         # Verify dataset was created successfully
@@ -352,48 +370,50 @@ class TestDatasetRequirements:
     def test_dataset_schema_validation_workflow(self, flow_with_requirements):
         """Test the typical workflow of using schema dataset for validation."""
         schema_dataset = flow_with_requirements.get_dataset_schema()
-        
+
         # Create a user dataset with correct schema
         correct_data = {
             "document": ["Sample document"],
-            "domain": ["Computer Science"], 
+            "domain": ["Computer Science"],
             "icl_document": ["Example document"],
-            "additional_info": ["Extra info"]
+            "additional_info": ["Extra info"],
         }
         user_dataset = Dataset.from_dict(correct_data)
-        
+
         # Schema validation should pass
         assert user_dataset.features == schema_dataset.features
-        
+
         # Create a user dataset with incorrect schema
         incorrect_data = {
             "document": ["Sample document"],
-            "wrong_column": ["Wrong data"]
+            "wrong_column": ["Wrong data"],
         }
         incorrect_dataset = Dataset.from_dict(incorrect_data)
-        
+
         # Schema validation should fail
         assert incorrect_dataset.features != schema_dataset.features
 
     def test_add_data_to_schema_dataset(self, flow_with_requirements):
         """Test adding data to the schema dataset."""
         schema_dataset = flow_with_requirements.get_dataset_schema()
-        
+
         # Should start empty
         assert len(schema_dataset) == 0
-        
+
         # Add a single item
-        populated_dataset = schema_dataset.add_item({
-            "document": "Test document",
-            "domain": "Test domain",
-            "icl_document": "Test ICL document", 
-            "additional_info": "Test info"
-        })
-        
+        populated_dataset = schema_dataset.add_item(
+            {
+                "document": "Test document",
+                "domain": "Test domain",
+                "icl_document": "Test ICL document",
+                "additional_info": "Test info",
+            }
+        )
+
         # Should now have one item
         assert len(populated_dataset) == 1
         assert populated_dataset["document"][0] == "Test document"
         assert populated_dataset["domain"][0] == "Test domain"
-        
+
         # Original schema dataset should still be empty
         assert len(schema_dataset) == 0

--- a/tests/flow/test_dataset_requirements.py
+++ b/tests/flow/test_dataset_requirements.py
@@ -1,0 +1,399 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for dataset requirements functionality."""
+
+# Standard
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+# Third Party
+from datasets import Dataset
+import datasets
+import pytest
+import yaml
+
+# First Party
+from sdg_hub import Flow
+from sdg_hub.core.flow.metadata import DatasetRequirements
+
+
+class TestDatasetRequirements:
+    """Test dataset requirements functionality."""
+
+    @pytest.fixture
+    def flow_with_requirements(self, temp_dir, mock_block):
+        """Create a flow with dataset requirements."""
+        flow_config = {
+            "metadata": {
+                "name": "Test Flow with Requirements",
+                "description": "Test flow for dataset requirements",
+                "version": "1.0.0",
+                "author": "Test Suite",
+                "dataset_requirements": {
+                    "required_columns": ["document", "domain", "icl_document"],
+                    "optional_columns": ["additional_info"],
+                    "min_samples": 1,
+                    "max_samples": 1000,
+                    "column_types": {
+                        "document": "string",
+                        "domain": "string",
+                        "icl_document": "string",
+                        "additional_info": "string",
+                    },
+                    "description": "Test dataset requirements",
+                },
+            },
+            "blocks": [
+                {
+                    "block_type": "ProcessorBlock",
+                    "block_config": {
+                        "block_name": "processor",
+                        "input_cols": "document",
+                        "output_cols": "processed",
+                    },
+                },
+            ],
+        }
+
+        yaml_path = Path(temp_dir) / "flow_with_requirements.yaml"
+        with open(yaml_path, "w", encoding="utf-8") as f:
+            yaml.dump(flow_config, f)
+
+        # Mock the block registry
+        with patch("sdg_hub.core.flow.base.BlockRegistry") as mock_registry:
+
+            def mock_get(_block_type):
+                mock_class = Mock()
+                mock_instance = mock_block("processor", ["document"], ["processed"])
+                mock_class.return_value = mock_instance
+                return mock_class
+
+            mock_registry._get.side_effect = mock_get
+            flow = Flow.from_yaml(str(yaml_path))
+
+        return flow
+
+    @pytest.fixture
+    def flow_without_requirements(self, temp_dir, mock_block):
+        """Create a flow without dataset requirements."""
+        flow_config = {
+            "metadata": {
+                "name": "Test Flow without Requirements",
+                "description": "Test flow without dataset requirements",
+                "version": "1.0.0",
+                "author": "Test Suite",
+            },
+            "blocks": [
+                {
+                    "block_type": "ProcessorBlock",
+                    "block_config": {
+                        "block_name": "processor",
+                        "input_cols": "input",
+                        "output_cols": "output",
+                    },
+                },
+            ],
+        }
+
+        yaml_path = Path(temp_dir) / "flow_without_requirements.yaml"
+        with open(yaml_path, "w", encoding="utf-8") as f:
+            yaml.dump(flow_config, f)
+
+        # Mock the block registry
+        with patch("sdg_hub.core.flow.base.BlockRegistry") as mock_registry:
+
+            def mock_get(_block_type):
+                mock_class = Mock()
+                mock_instance = mock_block("processor", ["input"], ["output"])
+                mock_class.return_value = mock_instance
+                return mock_class
+
+            mock_registry._get.side_effect = mock_get
+            flow = Flow.from_yaml(str(yaml_path))
+
+        return flow
+
+    def test_get_dataset_requirements_with_requirements(self, flow_with_requirements):
+        """Test get_dataset_requirements with flow that has requirements."""
+        requirements = flow_with_requirements.get_dataset_requirements()
+
+        assert requirements is not None
+        assert isinstance(requirements, DatasetRequirements)
+        assert requirements.required_columns == ["document", "domain", "icl_document"]
+        assert requirements.optional_columns == ["additional_info"]
+        assert requirements.min_samples == 1
+        assert requirements.max_samples == 1000
+        assert requirements.column_types == {
+            "document": "string",
+            "domain": "string",
+            "icl_document": "string",
+            "additional_info": "string",
+        }
+        assert requirements.description == "Test dataset requirements"
+
+    def test_get_dataset_requirements_without_requirements(self, flow_without_requirements):
+        """Test get_dataset_requirements with flow that has no requirements."""
+        requirements = flow_without_requirements.get_dataset_requirements()
+
+        assert requirements is None
+
+    def test_get_dataset_schema_with_requirements(self, flow_with_requirements):
+        """Test get_dataset_schema with flow that has requirements."""
+        schema_dataset = flow_with_requirements.get_dataset_schema()
+
+        assert isinstance(schema_dataset, Dataset)
+        assert len(schema_dataset) == 0  # Empty dataset
+        assert len(schema_dataset.column_names) == 4  # 3 required + 1 optional
+
+        # Check required columns
+        assert "document" in schema_dataset.column_names
+        assert "domain" in schema_dataset.column_names
+        assert "icl_document" in schema_dataset.column_names
+
+        # Check optional columns
+        assert "additional_info" in schema_dataset.column_names
+
+        # Check all are string type
+        for col_name in schema_dataset.column_names:
+            feature = schema_dataset.features[col_name]
+            assert isinstance(feature, datasets.Value)
+            assert feature.dtype == "string"
+
+    def test_get_dataset_schema_without_requirements(self, flow_without_requirements):
+        """Test get_dataset_schema with flow that has no requirements."""
+        schema_dataset = flow_without_requirements.get_dataset_schema()
+
+        assert isinstance(schema_dataset, Dataset)
+        assert len(schema_dataset) == 0  # Empty dataset
+        assert len(schema_dataset.column_names) == 0  # No columns
+
+    def test_get_dataset_schema_type_mapping(self, temp_dir, mock_block):
+        """Test that column types are correctly mapped to HuggingFace types."""
+        flow_config = {
+            "metadata": {
+                "name": "Test Flow Type Mapping",
+                "description": "Test flow for type mapping",
+                "version": "1.0.0",
+                "author": "Test Suite",
+                "dataset_requirements": {
+                    "required_columns": ["text_col", "int_col", "float_col", "bool_col", "unknown_col"],
+                    "column_types": {
+                        "text_col": "string",
+                        "int_col": "integer",
+                        "float_col": "float",
+                        "bool_col": "boolean",
+                        "unknown_col": "unknown_type",
+                    },
+                },
+            },
+            "blocks": [
+                {
+                    "block_type": "ProcessorBlock",
+                    "block_config": {
+                        "block_name": "processor",
+                        "input_cols": "text_col",
+                        "output_cols": "output",
+                    },
+                },
+            ],
+        }
+
+        yaml_path = Path(temp_dir) / "flow_type_mapping.yaml"
+        with open(yaml_path, "w", encoding="utf-8") as f:
+            yaml.dump(flow_config, f)
+
+        # Mock the block registry
+        with patch("sdg_hub.core.flow.base.BlockRegistry") as mock_registry:
+
+            def mock_get(_block_type):
+                mock_class = Mock()
+                mock_instance = mock_block("processor", ["text_col"], ["output"])
+                mock_class.return_value = mock_instance
+                return mock_class
+
+            mock_registry._get.side_effect = mock_get
+            flow = Flow.from_yaml(str(yaml_path))
+
+        schema_dataset = flow.get_dataset_schema()
+
+        # Check type mappings
+        assert schema_dataset.features["text_col"].dtype == "string"
+        assert schema_dataset.features["int_col"].dtype == "int64"
+        assert schema_dataset.features["float_col"].dtype == "float64"
+        assert schema_dataset.features["bool_col"].dtype == "bool"
+        assert schema_dataset.features["unknown_col"].dtype == "string"  # Unknown types default to string
+
+    def test_get_dataset_schema_alternative_type_names(self, temp_dir, mock_block):
+        """Test that alternative type names are correctly mapped."""
+        flow_config = {
+            "metadata": {
+                "name": "Test Flow Alternative Types",
+                "description": "Test flow for alternative type names",
+                "version": "1.0.0",
+                "author": "Test Suite",
+                "dataset_requirements": {
+                    "required_columns": ["str_col", "text_col", "int_col", "number_col", "bool_col"],
+                    "column_types": {
+                        "str_col": "str",
+                        "text_col": "text",
+                        "int_col": "int",
+                        "number_col": "number",
+                        "bool_col": "bool",
+                    },
+                },
+            },
+            "blocks": [
+                {
+                    "block_type": "ProcessorBlock",
+                    "block_config": {
+                        "block_name": "processor",
+                        "input_cols": "str_col",
+                        "output_cols": "output",
+                    },
+                },
+            ],
+        }
+
+        yaml_path = Path(temp_dir) / "flow_alt_types.yaml"
+        with open(yaml_path, "w", encoding="utf-8") as f:
+            yaml.dump(flow_config, f)
+
+        # Mock the block registry
+        with patch("sdg_hub.core.flow.base.BlockRegistry") as mock_registry:
+
+            def mock_get(_block_type):
+                mock_class = Mock()
+                mock_instance = mock_block("processor", ["str_col"], ["output"])
+                mock_class.return_value = mock_instance
+                return mock_class
+
+            mock_registry._get.side_effect = mock_get
+            flow = Flow.from_yaml(str(yaml_path))
+
+        schema_dataset = flow.get_dataset_schema()
+
+        # Check alternative type mappings
+        assert schema_dataset.features["str_col"].dtype == "string"
+        assert schema_dataset.features["text_col"].dtype == "string"
+        assert schema_dataset.features["int_col"].dtype == "int64"
+        assert schema_dataset.features["number_col"].dtype == "float64"
+        assert schema_dataset.features["bool_col"].dtype == "bool"
+
+    def test_dataset_schema_compatibility_with_huggingface(self, flow_with_requirements):
+        """Test that the schema dataset can be used with HuggingFace datasets."""
+        schema_dataset = flow_with_requirements.get_dataset_schema()
+
+        # Add sample data to the schema dataset
+        sample_data = {
+            col_name: "sample_value" for col_name in schema_dataset.column_names
+        }
+        
+        populated_dataset = schema_dataset.add_item(sample_data)
+
+        # Verify dataset was created successfully
+        assert isinstance(populated_dataset, Dataset)
+        assert len(populated_dataset) == 1
+        assert set(populated_dataset.column_names) == set(schema_dataset.column_names)
+
+        # Verify feature types match
+        for col_name in schema_dataset.column_names:
+            expected_type = schema_dataset.features[col_name]
+            actual_type = populated_dataset.features[col_name]
+            assert actual_type.dtype == expected_type.dtype
+
+    def test_get_dataset_schema_no_column_types_specified(self, temp_dir, mock_block):
+        """Test get_dataset_schema when no column types are specified."""
+        flow_config = {
+            "metadata": {
+                "name": "Test Flow No Types",
+                "description": "Test flow without column types",
+                "version": "1.0.0",
+                "author": "Test Suite",
+                "dataset_requirements": {
+                    "required_columns": ["col1", "col2"],
+                    "optional_columns": ["col3"],
+                    # No column_types specified
+                },
+            },
+            "blocks": [
+                {
+                    "block_type": "ProcessorBlock",
+                    "block_config": {
+                        "block_name": "processor",
+                        "input_cols": "col1",
+                        "output_cols": "output",
+                    },
+                },
+            ],
+        }
+
+        yaml_path = Path(temp_dir) / "flow_no_types.yaml"
+        with open(yaml_path, "w", encoding="utf-8") as f:
+            yaml.dump(flow_config, f)
+
+        # Mock the block registry
+        with patch("sdg_hub.core.flow.base.BlockRegistry") as mock_registry:
+
+            def mock_get(_block_type):
+                mock_class = Mock()
+                mock_instance = mock_block("processor", ["col1"], ["output"])
+                mock_class.return_value = mock_instance
+                return mock_class
+
+            mock_registry._get.side_effect = mock_get
+            flow = Flow.from_yaml(str(yaml_path))
+
+        schema_dataset = flow.get_dataset_schema()
+
+        # All columns should default to string type
+        for col_name in schema_dataset.column_names:
+            assert schema_dataset.features[col_name].dtype == "string"
+        assert len(schema_dataset.column_names) == 3  # 2 required + 1 optional
+
+    def test_dataset_schema_validation_workflow(self, flow_with_requirements):
+        """Test the typical workflow of using schema dataset for validation."""
+        schema_dataset = flow_with_requirements.get_dataset_schema()
+        
+        # Create a user dataset with correct schema
+        correct_data = {
+            "document": ["Sample document"],
+            "domain": ["Computer Science"], 
+            "icl_document": ["Example document"],
+            "additional_info": ["Extra info"]
+        }
+        user_dataset = Dataset.from_dict(correct_data)
+        
+        # Schema validation should pass
+        assert user_dataset.features == schema_dataset.features
+        
+        # Create a user dataset with incorrect schema
+        incorrect_data = {
+            "document": ["Sample document"],
+            "wrong_column": ["Wrong data"]
+        }
+        incorrect_dataset = Dataset.from_dict(incorrect_data)
+        
+        # Schema validation should fail
+        assert incorrect_dataset.features != schema_dataset.features
+
+    def test_add_data_to_schema_dataset(self, flow_with_requirements):
+        """Test adding data to the schema dataset."""
+        schema_dataset = flow_with_requirements.get_dataset_schema()
+        
+        # Should start empty
+        assert len(schema_dataset) == 0
+        
+        # Add a single item
+        populated_dataset = schema_dataset.add_item({
+            "document": "Test document",
+            "domain": "Test domain",
+            "icl_document": "Test ICL document", 
+            "additional_info": "Test info"
+        })
+        
+        # Should now have one item
+        assert len(populated_dataset) == 1
+        assert populated_dataset["document"][0] == "Test document"
+        assert populated_dataset["domain"][0] == "Test domain"
+        
+        # Original schema dataset should still be empty
+        assert len(schema_dataset) == 0


### PR DESCRIPTION
## Summary

This PR introduces powerful new methods to help users easily discover and work with dataset requirements for flows, solving the common pain point of "what data format does this flow need?"

### New Features

- **`get_dataset_requirements()`** - Access raw dataset requirements object
- **`get_dataset_schema()`** - Get empty Dataset with correct schema for immediate use
- **Schema validation** - Compare `my_dataset.features == schema_dataset.features`
- **Direct data addition** - Use `schema_dataset.add_item()` to build datasets incrementally

### Key Benefits

✅ **No more guessing** - Instantly see what columns and types a flow needs  
✅ **Easy validation** - Simple feature comparison to check schema compatibility  
✅ **Immediate usability** - Get ready-to-use empty datasets  
✅ **Backward compatible** - Existing code continues to work unchanged  

### Usage Examples

```python
# Discover what data the flow needs
schema_dataset = flow.get_dataset_schema()
print(f"Required columns: {schema_dataset.column_names}")

# Add data directly
dataset = schema_dataset.add_item({
    "document": "Your text here",
    "domain": "Computer Science"
})

# Validate existing data
if my_dataset.features == schema_dataset.features:
    print("✅ Schema matches!")
```

### Implementation Details

- Added 2 new methods to `Flow` class in `src/sdg_hub/core/flow/base.py`
- Comprehensive test suite with 10 test cases covering all scenarios
- Type mapping supports string, int, float, bool with sensible defaults
- Updated README.md with examples and new feature documentation

### Test Coverage

- ✅ Flows with and without dataset requirements
- ✅ Type mapping for different column types  
- ✅ HuggingFace compatibility verification
- ✅ Schema validation workflows
- ✅ Direct data addition to schema datasets

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced Dataset Schema Discovery to fetch an empty dataset with required columns/types, populate it, or validate your own dataset; added inspectable dataset requirements (required/optional columns, min samples) and robust type mapping (string, int, float, bool and common aliases).

* **Documentation**
  * README updated to a schema-first workflow: discover requirements, create/validate datasets, then dry run and generate; example renamed accordingly.

* **Tests**
  * Added comprehensive tests for schema discovery, type mapping, validation, and dataset population.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->