### PR TITLE
Fix retry counting for expand_lists=False in LLMChatWithParsingRetryBlock

### DIFF
--- a/src/sdg_hub/core/blocks/llm/llm_chat_with_parsing_retry_block.py
+++ b/src/sdg_hub/core/blocks/llm/llm_chat_with_parsing_retry_block.py
@@ -427,14 +427,14 @@ class LLMChatWithParsingRetryBlock(BaseBlock):
                                 for parsed_row in parsed_result:
                                     if total_parsed_count >= target:
                                         break
-                                    # Add parsed values to accumulated lists
-                                    for col in self.output_cols:
-                                        if col in parsed_row:
-                                            accumulated_parsed_items[col].append(
-                                                parsed_row[col]
-                                            )
-                                    total_parsed_count += 1
-                                    new_parsed_count += 1
+                                    
+                                    # Only count as successful if ALL output columns are present
+                                    if all(col in parsed_row for col in self.output_cols):
+                                        for col in self.output_cols:
+                                            accumulated_parsed_items[col].append(parsed_row[col])
+                                        total_parsed_count += 1
+                                        new_parsed_count += 1
+                                    # If any column is missing, skip this parsed response entirely
 
                         logger.debug(
                             f"Attempt {attempt + 1} for sample {sample_idx}: {new_parsed_count} successful parses "

--- a/src/sdg_hub/core/blocks/llm/llm_chat_with_parsing_retry_block.py
+++ b/src/sdg_hub/core/blocks/llm/llm_chat_with_parsing_retry_block.py
@@ -407,34 +407,30 @@ class LLMChatWithParsingRetryBlock(BaseBlock):
                             temp_parse_data = [{**sample, raw_response_col: response}]
                             temp_parse_dataset = Dataset.from_list(temp_parse_data)
 
+                            # Force expand_lists=True temporarily to get individual parsed items
+                            original_expand_lists = self.text_parser.expand_lists
                             try:
-                                # Force expand_lists=True temporarily to get individual parsed items
-                                original_expand_lists = self.text_parser.expand_lists
                                 self.text_parser.expand_lists = True
                                 parsed_result = self.text_parser.generate(
                                     temp_parse_dataset, **kwargs
                                 )
+                            except Exception as parse_e:
+                                logger.debug(f"Failed to parse individual response: {parse_e}")
+                                continue
+                            finally:
                                 self.text_parser.expand_lists = original_expand_lists
 
-                                # If parsing was successful, accumulate the results
-                                if len(parsed_result) > 0:
-                                    for parsed_row in parsed_result:
-                                        if total_parsed_count >= target:
-                                            break
-                                        # Add parsed values to accumulated lists
-                                        for col in self.output_cols:
-                                            if col in parsed_row:
-                                                accumulated_parsed_items[col].append(
-                                                    parsed_row[col]
-                                                )
-                                        total_parsed_count += 1
-                                        new_parsed_count += 1
-
-                            except Exception as parse_e:
-                                logger.debug(
-                                    f"Failed to parse individual response: {parse_e}"
-                                )
-                                continue
+                            # If parsing was successful, accumulate the results
+                            if len(parsed_result) > 0:
+                                for parsed_row in parsed_result:
+                                    if total_parsed_count >= target:
+                                        break
+                                    # Add parsed values to accumulated lists
+                                    for col in self.output_cols:
+                                        if col in parsed_row:
+                                            accumulated_parsed_items[col].append(parsed_row[col])
+                                    total_parsed_count += 1
+                                    new_parsed_count += 1
 
                         logger.debug(
                             f"Attempt {attempt + 1} for sample {sample_idx}: {new_parsed_count} successful parses "

--- a/src/sdg_hub/core/blocks/llm/llm_chat_with_parsing_retry_block.py
+++ b/src/sdg_hub/core/blocks/llm/llm_chat_with_parsing_retry_block.py
@@ -415,7 +415,9 @@ class LLMChatWithParsingRetryBlock(BaseBlock):
                                     temp_parse_dataset, **kwargs
                                 )
                             except Exception as parse_e:
-                                logger.debug(f"Failed to parse individual response: {parse_e}")
+                                logger.debug(
+                                    f"Failed to parse individual response: {parse_e}"
+                                )
                                 continue
                             finally:
                                 self.text_parser.expand_lists = original_expand_lists
@@ -428,7 +430,9 @@ class LLMChatWithParsingRetryBlock(BaseBlock):
                                     # Add parsed values to accumulated lists
                                     for col in self.output_cols:
                                         if col in parsed_row:
-                                            accumulated_parsed_items[col].append(parsed_row[col])
+                                            accumulated_parsed_items[col].append(
+                                                parsed_row[col]
+                                            )
                                     total_parsed_count += 1
                                     new_parsed_count += 1
 

--- a/src/sdg_hub/core/blocks/llm/llm_chat_with_parsing_retry_block.py
+++ b/src/sdg_hub/core/blocks/llm/llm_chat_with_parsing_retry_block.py
@@ -303,9 +303,6 @@ class LLMChatWithParsingRetryBlock(BaseBlock):
 
         # Process each sample independently with retry logic
         for sample_idx, sample in enumerate(samples):
-            sample_results = []
-            total_parsed_count = 0
-
             # Determine target count for this sample (number of completions requested)
             target = kwargs.get("n", self.llm_params.get("n")) or 1
 
@@ -318,61 +315,179 @@ class LLMChatWithParsingRetryBlock(BaseBlock):
                 },
             )
 
-            # Retry loop for this sample
-            for attempt in range(self.parsing_max_retries):
-                if total_parsed_count >= target:
-                    break  # Already reached target
+            if self.text_parser.expand_lists:
+                # Current behavior for expand_lists=True: count rows directly
+                sample_results = []
+                total_parsed_count = 0
 
-                try:
-                    # Generate LLM responses for this sample
-                    temp_dataset = Dataset.from_list([sample])
-                    llm_result = self.llm_chat.generate(temp_dataset, **kwargs)
-
-                    # Parse the responses
-                    parsed_result = self.text_parser.generate(llm_result, **kwargs)
-
-                    # Count successful parses and accumulate results
-                    new_parsed_count = len(parsed_result)
-                    total_parsed_count += new_parsed_count
-                    sample_results.extend(parsed_result)
-
-                    logger.debug(
-                        f"Attempt {attempt + 1} for sample {sample_idx}: {new_parsed_count} successful parses "
-                        f"(total: {total_parsed_count}/{target})",
-                        extra={
-                            "block_name": self.block_name,
-                            "sample_idx": sample_idx,
-                            "attempt": attempt + 1,
-                            "new_parses": new_parsed_count,
-                            "total_parses": total_parsed_count,
-                            "target_count": target,
-                        },
-                    )
-
+                # Retry loop for this sample
+                for attempt in range(self.parsing_max_retries):
                     if total_parsed_count >= target:
+                        break  # Already reached target
+
+                    try:
+                        # Generate LLM responses for this sample
+                        temp_dataset = Dataset.from_list([sample])
+                        llm_result = self.llm_chat.generate(temp_dataset, **kwargs)
+
+                        # Parse the responses
+                        parsed_result = self.text_parser.generate(llm_result, **kwargs)
+
+                        # Count successful parses and accumulate results
+                        new_parsed_count = len(parsed_result)
+                        total_parsed_count += new_parsed_count
+                        sample_results.extend(parsed_result)
+
                         logger.debug(
-                            f"Target reached for sample {sample_idx} after {attempt + 1} attempts",
+                            f"Attempt {attempt + 1} for sample {sample_idx}: {new_parsed_count} successful parses "
+                            f"(total: {total_parsed_count}/{target})",
                             extra={
                                 "block_name": self.block_name,
                                 "sample_idx": sample_idx,
-                                "attempts": attempt + 1,
-                                "final_count": total_parsed_count,
+                                "attempt": attempt + 1,
+                                "new_parses": new_parsed_count,
+                                "total_parses": total_parsed_count,
+                                "target_count": target,
                             },
                         )
-                        break
 
-                except Exception as e:
-                    logger.warning(
-                        f"Error during attempt {attempt + 1} for sample {sample_idx}: {e}",
-                        extra={
-                            "block_name": self.block_name,
-                            "sample_idx": sample_idx,
-                            "attempt": attempt + 1,
-                            "error": str(e),
-                        },
-                    )
-                    # Continue to next attempt
-                    continue
+                        if total_parsed_count >= target:
+                            logger.debug(
+                                f"Target reached for sample {sample_idx} after {attempt + 1} attempts",
+                                extra={
+                                    "block_name": self.block_name,
+                                    "sample_idx": sample_idx,
+                                    "attempts": attempt + 1,
+                                    "final_count": total_parsed_count,
+                                },
+                            )
+                            break
+
+                    except Exception as e:
+                        logger.warning(
+                            f"Error during attempt {attempt + 1} for sample {sample_idx}: {e}",
+                            extra={
+                                "block_name": self.block_name,
+                                "sample_idx": sample_idx,
+                                "attempt": attempt + 1,
+                                "error": str(e),
+                            },
+                        )
+                        # Continue to next attempt
+                        continue
+
+            else:
+                # New behavior for expand_lists=False: parse individual responses and accumulate
+                accumulated_parsed_items = {col: [] for col in self.output_cols}
+                total_parsed_count = 0
+
+                # Retry loop for this sample
+                for attempt in range(self.parsing_max_retries):
+                    if total_parsed_count >= target:
+                        break  # Already reached target
+
+                    try:
+                        # Generate LLM responses for this sample
+                        temp_dataset = Dataset.from_list([sample])
+                        llm_result = self.llm_chat.generate(temp_dataset, **kwargs)
+
+                        # Get the raw responses (should be a list when n > 1)
+                        raw_response_col = f"{self.block_name}_raw_response"
+                        raw_responses = llm_result[0][raw_response_col]
+                        if not isinstance(raw_responses, list):
+                            raw_responses = [raw_responses]
+
+                        # Parse each response individually and accumulate successful ones
+                        new_parsed_count = 0
+                        for response in raw_responses:
+                            if total_parsed_count >= target:
+                                break  # Stop if we've reached target
+
+                            # Create temporary dataset with single response for parsing
+                            temp_parse_data = [{**sample, raw_response_col: response}]
+                            temp_parse_dataset = Dataset.from_list(temp_parse_data)
+
+                            try:
+                                # Force expand_lists=True temporarily to get individual parsed items
+                                original_expand_lists = self.text_parser.expand_lists
+                                self.text_parser.expand_lists = True
+                                parsed_result = self.text_parser.generate(
+                                    temp_parse_dataset, **kwargs
+                                )
+                                self.text_parser.expand_lists = original_expand_lists
+
+                                # If parsing was successful, accumulate the results
+                                if len(parsed_result) > 0:
+                                    for parsed_row in parsed_result:
+                                        if total_parsed_count >= target:
+                                            break
+                                        # Add parsed values to accumulated lists
+                                        for col in self.output_cols:
+                                            if col in parsed_row:
+                                                accumulated_parsed_items[col].append(
+                                                    parsed_row[col]
+                                                )
+                                        total_parsed_count += 1
+                                        new_parsed_count += 1
+
+                            except Exception as parse_e:
+                                logger.debug(
+                                    f"Failed to parse individual response: {parse_e}"
+                                )
+                                continue
+
+                        logger.debug(
+                            f"Attempt {attempt + 1} for sample {sample_idx}: {new_parsed_count} successful parses "
+                            f"(total: {total_parsed_count}/{target})",
+                            extra={
+                                "block_name": self.block_name,
+                                "sample_idx": sample_idx,
+                                "attempt": attempt + 1,
+                                "new_parses": new_parsed_count,
+                                "total_parses": total_parsed_count,
+                                "target_count": target,
+                            },
+                        )
+
+                        if total_parsed_count >= target:
+                            logger.debug(
+                                f"Target reached for sample {sample_idx} after {attempt + 1} attempts",
+                                extra={
+                                    "block_name": self.block_name,
+                                    "sample_idx": sample_idx,
+                                    "attempts": attempt + 1,
+                                    "final_count": total_parsed_count,
+                                },
+                            )
+                            break
+
+                    except Exception as e:
+                        logger.warning(
+                            f"Error during attempt {attempt + 1} for sample {sample_idx}: {e}",
+                            extra={
+                                "block_name": self.block_name,
+                                "sample_idx": sample_idx,
+                                "attempt": attempt + 1,
+                                "error": str(e),
+                            },
+                        )
+                        # Continue to next attempt
+                        continue
+
+                # Create final result row with accumulated lists
+                if total_parsed_count > 0:
+                    # Trim to exact target count if needed
+                    for col in self.output_cols:
+                        if len(accumulated_parsed_items[col]) > target:
+                            accumulated_parsed_items[col] = accumulated_parsed_items[
+                                col
+                            ][:target]
+
+                    # Only add the parsed output columns as lists, preserve other columns as-is
+                    final_row = {**sample, **accumulated_parsed_items}
+                    sample_results = [final_row]
+                else:
+                    sample_results = []
 
             # Check if we reached the target count
             if total_parsed_count < target:
@@ -382,8 +497,8 @@ class LLMChatWithParsingRetryBlock(BaseBlock):
                     max_retries=self.parsing_max_retries,
                 )
 
-            # Trim results to exact target count if we exceeded it
-            if total_parsed_count > target:
+            # For expand_lists=True, trim results to exact target count if we exceeded it
+            if self.text_parser.expand_lists and total_parsed_count > target:
                 sample_results = sample_results[:target]
                 logger.debug(
                     f"Trimmed sample {sample_idx} results from {total_parsed_count} to {target}",

--- a/src/sdg_hub/core/blocks/llm/llm_chat_with_parsing_retry_block.py
+++ b/src/sdg_hub/core/blocks/llm/llm_chat_with_parsing_retry_block.py
@@ -427,11 +427,15 @@ class LLMChatWithParsingRetryBlock(BaseBlock):
                                 for parsed_row in parsed_result:
                                     if total_parsed_count >= target:
                                         break
-                                    
+
                                     # Only count as successful if ALL output columns are present
-                                    if all(col in parsed_row for col in self.output_cols):
+                                    if all(
+                                        col in parsed_row for col in self.output_cols
+                                    ):
                                         for col in self.output_cols:
-                                            accumulated_parsed_items[col].append(parsed_row[col])
+                                            accumulated_parsed_items[col].append(
+                                                parsed_row[col]
+                                            )
                                         total_parsed_count += 1
                                         new_parsed_count += 1
                                     # If any column is missing, skip this parsed response entirely

--- a/src/sdg_hub/core/blocks/llm/text_parser_block.py
+++ b/src/sdg_hub/core/blocks/llm/text_parser_block.py
@@ -278,8 +278,6 @@ class TextParserBlock(BaseBlock):
                     return []
 
                 # Return single row with lists as values
-                # TODO: This breaks retry counting in LLMChatWithParsingRetryBlock until LLMChatWithParsingRetryBlock is re-based
-                # which expects one row per successful parse for counting
                 return [{**sample, **all_parsed_outputs}]
 
             else:

--- a/tests/blocks/llm/test_llm_chat_with_parsing_retry_block.py
+++ b/tests/blocks/llm/test_llm_chat_with_parsing_retry_block.py
@@ -962,12 +962,17 @@ class TestLLMChatWithParsingRetryBlockExpandListsFalse:
 
             # Mock the text parser to throw an exception during generate
             original_generate = block.text_parser.generate
+
             def mock_generate_with_exception(*args, **kwargs):
-                if block.text_parser.expand_lists is True:  # Only throw when temporarily True
+                if (
+                    block.text_parser.expand_lists is True
+                ):  # Only throw when temporarily True
                     raise ValueError("Simulated parsing exception")
                 return original_generate(*args, **kwargs)
 
-            with patch.object(block.text_parser, 'generate', side_effect=mock_generate_with_exception):
+            with patch.object(
+                block.text_parser, "generate", side_effect=mock_generate_with_exception
+            ):
                 single_dataset = Dataset.from_dict(
                     {"messages": [sample_dataset["messages"][0]]}
                 )

--- a/tests/blocks/llm/test_llm_chat_with_parsing_retry_block.py
+++ b/tests/blocks/llm/test_llm_chat_with_parsing_retry_block.py
@@ -770,6 +770,264 @@ class TestLLMChatWithParsingRetryBlockRegistration:
         )
 
 
+class TestLLMChatWithParsingRetryBlockExpandListsFalse:
+    """Test expand_lists=False behavior for retry counting."""
+
+    def test_expand_lists_false_successful_first_attempt(
+        self, mock_litellm_completion_multiple, sample_dataset
+    ):
+        """Test expand_lists=False with successful parsing on first attempt."""
+        block = LLMChatWithParsingRetryBlock(
+            block_name="test_expand_false",
+            input_cols="messages",
+            output_cols="answer",
+            model="openai/gpt-4",
+            start_tags=["<answer>"],
+            end_tags=["</answer>"],
+            expand_lists=False,  # Key: disable list expansion
+            n=3,  # Request 3 responses
+            parsing_max_retries=2,
+        )
+
+        result = block.generate(sample_dataset)
+
+        # Should return 2 rows (one per input sample) with lists as values
+        assert len(result) == 2
+        for row in result:
+            assert "answer" in row
+            assert isinstance(row["answer"], list)
+            assert len(row["answer"]) == 3  # All 3 responses parsed successfully
+            assert row["answer"] == ["Response 1", "Response 2", "Response 3"]
+
+        # Should only call LLM once per sample (no retries needed)
+        assert mock_litellm_completion_multiple.call_count == 2
+
+    def test_expand_lists_false_partial_success_with_retry(self, sample_dataset):
+        """Test expand_lists=False with partial success requiring retries."""
+        with patch(
+            "sdg_hub.core.blocks.llm.client_manager.completion"
+        ) as mock_completion:
+            # First call: 2 responses, only 1 parseable
+            mock_response_1 = MagicMock()
+            mock_response_1.choices = [MagicMock(), MagicMock()]
+            mock_response_1.choices[0].message.content = "<answer>First good</answer>"
+            mock_response_1.choices[1].message.content = "Unparseable response"
+
+            # Second call: 2 responses, only 1 parseable (should reach target of 2)
+            mock_response_2 = MagicMock()
+            mock_response_2.choices = [MagicMock(), MagicMock()]
+            mock_response_2.choices[0].message.content = "<answer>Second good</answer>"
+            mock_response_2.choices[1].message.content = "Also unparseable"
+
+            mock_completion.side_effect = [mock_response_1, mock_response_2] * 2
+
+            block = LLMChatWithParsingRetryBlock(
+                block_name="test_expand_false_retry",
+                input_cols="messages",
+                output_cols="answer",
+                model="openai/gpt-4",
+                start_tags=["<answer>"],
+                end_tags=["</answer>"],
+                expand_lists=False,
+                n=2,  # Need 2 successful parses
+                parsing_max_retries=3,
+            )
+
+            result = block.generate(sample_dataset)
+
+            # Should return 2 rows with accumulated successful parses as lists
+            assert len(result) == 2
+            for row in result:
+                assert isinstance(row["answer"], list)
+                assert len(row["answer"]) == 2
+                assert row["answer"] == ["First good", "Second good"]
+
+            # Should call LLM twice per sample (1 retry each)
+            assert mock_completion.call_count == 4
+
+    def test_expand_lists_false_max_retries_exceeded(self, sample_dataset):
+        """Test expand_lists=False with MaxRetriesExceededError."""
+        with patch(
+            "sdg_hub.core.blocks.llm.client_manager.completion"
+        ) as mock_completion:
+            # Always return 1 parseable out of 3 needed
+            mock_response = MagicMock()
+            mock_response.choices = [MagicMock(), MagicMock()]
+            mock_response.choices[0].message.content = "<answer>Only one good</answer>"
+            mock_response.choices[1].message.content = "Unparseable"
+            mock_completion.return_value = mock_response
+
+            block = LLMChatWithParsingRetryBlock(
+                block_name="test_expand_false_failure",
+                input_cols="messages",
+                output_cols="answer",
+                model="openai/gpt-4",
+                start_tags=["<answer>"],
+                end_tags=["</answer>"],
+                expand_lists=False,
+                n=3,  # Need 3 successful parses
+                parsing_max_retries=2,
+            )
+
+            single_dataset = Dataset.from_dict(
+                {"messages": [sample_dataset["messages"][0]]}
+            )
+
+            with pytest.raises(MaxRetriesExceededError) as exc_info:
+                block.generate(single_dataset)
+
+            error = exc_info.value
+            assert error.target_count == 3
+            assert error.actual_count == 2  # Got 1 per retry × 2 retries
+            assert error.max_retries == 2
+
+    def test_expand_lists_false_vs_true_comparison(self, sample_dataset):
+        """Test that expand_lists=False vs True produce different output structures."""
+        with patch(
+            "sdg_hub.core.blocks.llm.client_manager.completion"
+        ) as mock_completion:
+            mock_response = MagicMock()
+            mock_response.choices = [MagicMock(), MagicMock()]
+            mock_response.choices[0].message.content = "<answer>Response 1</answer>"
+            mock_response.choices[1].message.content = "<answer>Response 2</answer>"
+            mock_completion.return_value = mock_response
+
+            # Test expand_lists=False
+            block_false = LLMChatWithParsingRetryBlock(
+                block_name="test_false",
+                input_cols="messages",
+                output_cols="answer",
+                model="openai/gpt-4",
+                start_tags=["<answer>"],
+                end_tags=["</answer>"],
+                expand_lists=False,
+                n=2,
+            )
+
+            # Test expand_lists=True (default)
+            block_true = LLMChatWithParsingRetryBlock(
+                block_name="test_true",
+                input_cols="messages",
+                output_cols="answer",
+                model="openai/gpt-4",
+                start_tags=["<answer>"],
+                end_tags=["</answer>"],
+                expand_lists=True,
+                n=2,
+            )
+
+            single_dataset = Dataset.from_dict(
+                {"messages": [sample_dataset["messages"][0]]}
+            )
+
+            result_false = block_false.generate(single_dataset)
+            mock_completion.reset_mock()  # Reset call count
+            result_true = block_true.generate(single_dataset)
+
+            # expand_lists=False: 1 row with list values
+            assert len(result_false) == 1
+            assert isinstance(result_false[0]["answer"], list)
+            assert result_false[0]["answer"] == ["Response 1", "Response 2"]
+
+            # expand_lists=True: 2 rows with individual values
+            assert len(result_true) == 2
+            assert result_true[0]["answer"] == "Response 1"
+            assert result_true[1]["answer"] == "Response 2"
+
+    def test_non_list_columns_preserved_both_modes(self):
+        """Test that non-output columns are preserved with correct types in both expand_lists modes."""
+        with patch(
+            "sdg_hub.core.blocks.llm.client_manager.completion"
+        ) as mock_completion:
+            mock_response = MagicMock()
+            mock_response.choices = [MagicMock(), MagicMock()]
+            mock_response.choices[0].message.content = "<answer>Response 1</answer>"
+            mock_response.choices[1].message.content = "<answer>Response 2</answer>"
+            mock_completion.return_value = mock_response
+
+            # Create dataset with various column types that should be preserved
+            test_dataset = Dataset.from_dict(
+                {
+                    "messages": [[{"role": "user", "content": "test"}]],
+                    "context_id": [123],  # integer
+                    "user_name": ["alice"],  # string
+                    "is_premium": [True],  # boolean
+                    "metadata": [{"key": "value"}],  # dict
+                }
+            )
+
+            # Test expand_lists=False
+            block_false = LLMChatWithParsingRetryBlock(
+                block_name="test_preserve_false",
+                input_cols="messages",
+                output_cols="answer",
+                model="openai/gpt-4",
+                start_tags=["<answer>"],
+                end_tags=["</answer>"],
+                expand_lists=False,
+                n=2,
+            )
+
+            result_false = block_false.generate(test_dataset)
+
+            # Should have 1 row (expand_lists=False)
+            assert len(result_false) == 1
+            row = result_false[0]
+
+            # New parsed output column should be a list
+            assert isinstance(row["answer"], list)
+            assert row["answer"] == ["Response 1", "Response 2"]
+
+            # All original columns should be preserved with original types
+            assert row["context_id"] == 123
+            assert isinstance(row["context_id"], int)
+            assert row["user_name"] == "alice"
+            assert isinstance(row["user_name"], str)
+            assert row["is_premium"] is True
+            assert isinstance(row["is_premium"], bool)
+            assert row["metadata"] == {"key": "value"}
+            assert isinstance(row["metadata"], dict)
+            assert row["messages"] == [{"role": "user", "content": "test"}]
+            assert isinstance(row["messages"], list)
+
+            mock_completion.reset_mock()
+
+            # Test expand_lists=True
+            block_true = LLMChatWithParsingRetryBlock(
+                block_name="test_preserve_true",
+                input_cols="messages",
+                output_cols="answer",
+                model="openai/gpt-4",
+                start_tags=["<answer>"],
+                end_tags=["</answer>"],
+                expand_lists=True,
+                n=2,
+            )
+
+            result_true = block_true.generate(test_dataset)
+
+            # Should have 2 rows (expand_lists=True)
+            assert len(result_true) == 2
+
+            for i, row in enumerate(result_true):
+                # New parsed output column should be individual strings
+                expected_answer = f"Response {i + 1}"
+                assert row["answer"] == expected_answer
+                assert isinstance(row["answer"], str)
+
+                # All original columns should be preserved with original types
+                assert row["context_id"] == 123
+                assert isinstance(row["context_id"], int)
+                assert row["user_name"] == "alice"
+                assert isinstance(row["user_name"], str)
+                assert row["is_premium"] is True
+                assert isinstance(row["is_premium"], bool)
+                assert row["metadata"] == {"key": "value"}
+                assert isinstance(row["metadata"], dict)
+                assert row["messages"] == [{"role": "user", "content": "test"}]
+                assert isinstance(row["messages"], list)
+
+
 class TestLLMChatWithParsingRetryBlockIntegration:
     """Integration tests with real internal block behavior."""
 

--- a/tests/blocks/llm/test_llm_chat_with_parsing_retry_block.py
+++ b/tests/blocks/llm/test_llm_chat_with_parsing_retry_block.py
@@ -934,6 +934,51 @@ class TestLLMChatWithParsingRetryBlockExpandListsFalse:
             assert result_true[0]["answer"] == "Response 1"
             assert result_true[1]["answer"] == "Response 2"
 
+    def test_expand_lists_flag_restored_on_exception(self, sample_dataset):
+        """Test that expand_lists flag is properly restored even when parsing throws an exception."""
+        with patch(
+            "sdg_hub.core.blocks.llm.client_manager.completion"
+        ) as mock_completion:
+            # Mock successful LLM response
+            mock_response = MagicMock()
+            mock_response.choices = [MagicMock()]
+            mock_response.choices[0].message.content = "<answer>Response</answer>"
+            mock_completion.return_value = mock_response
+
+            block = LLMChatWithParsingRetryBlock(
+                block_name="test_flag_restore",
+                input_cols="messages",
+                output_cols="answer",
+                model="openai/gpt-4",
+                start_tags=["<answer>"],
+                end_tags=["</answer>"],
+                expand_lists=False,  # Original setting should be restored
+                n=1,
+                parsing_max_retries=2,
+            )
+
+            # Verify initial state
+            assert block.text_parser.expand_lists is False
+
+            # Mock the text parser to throw an exception during generate
+            original_generate = block.text_parser.generate
+            def mock_generate_with_exception(*args, **kwargs):
+                if block.text_parser.expand_lists is True:  # Only throw when temporarily True
+                    raise ValueError("Simulated parsing exception")
+                return original_generate(*args, **kwargs)
+
+            with patch.object(block.text_parser, 'generate', side_effect=mock_generate_with_exception):
+                single_dataset = Dataset.from_dict(
+                    {"messages": [sample_dataset["messages"][0]]}
+                )
+
+                # This should fail due to parsing exceptions, but expand_lists should be restored
+                with pytest.raises(MaxRetriesExceededError):
+                    block.generate(single_dataset)
+
+            # Critical assertion: expand_lists should be back to original False value
+            assert block.text_parser.expand_lists is False
+
     def test_non_list_columns_preserved_both_modes(self):
         """Test that non-output columns are preserved with correct types in both expand_lists modes."""
         with patch(

--- a/tests/blocks/llm/test_llm_chat_with_parsing_retry_block.py
+++ b/tests/blocks/llm/test_llm_chat_with_parsing_retry_block.py
@@ -984,6 +984,62 @@ class TestLLMChatWithParsingRetryBlockExpandListsFalse:
             # Critical assertion: expand_lists should be back to original False value
             assert block.text_parser.expand_lists is False
 
+    def test_partial_parses_rejected_expand_lists_false(self, sample_dataset):
+        """Test that partial parses (missing some output columns) are rejected when expand_lists=False."""
+        with patch(
+            "sdg_hub.core.blocks.llm.client_manager.completion"
+        ) as mock_completion:
+            # Mock responses where some have complete parses, others have partial parses
+            mock_response = MagicMock()
+            mock_response.choices = [MagicMock(), MagicMock(), MagicMock()]
+            # Response 1: Complete parse (both explanation and answer)
+            mock_response.choices[0].message.content = (
+                "<explanation>Complete explanation</explanation><answer>Complete answer</answer>"
+            )
+            # Response 2: Partial parse (only explanation, missing answer)
+            mock_response.choices[1].message.content = (
+                "<explanation>Partial explanation</explanation>No answer tag here"
+            )
+            # Response 3: Another complete parse
+            mock_response.choices[2].message.content = (
+                "<explanation>Another explanation</explanation><answer>Another answer</answer>"
+            )
+            mock_completion.return_value = mock_response
+
+            block = LLMChatWithParsingRetryBlock(
+                block_name="test_partial_reject",
+                input_cols="messages",
+                output_cols=["explanation", "answer"],  # Both columns required
+                model="openai/gpt-4",
+                start_tags=["<explanation>", "<answer>"],
+                end_tags=["</explanation>", "</answer>"],
+                expand_lists=False,
+                n=2,  # Want 2 complete parses
+                parsing_max_retries=3,
+            )
+
+            single_dataset = Dataset.from_dict(
+                {"messages": [sample_dataset["messages"][0]]}
+            )
+
+            result = block.generate(single_dataset)
+
+            # Should have 1 row with lists containing only the 2 complete parses
+            assert len(result) == 1
+            row = result[0]
+            
+            # Both lists should have exactly 2 items (only complete parses counted)
+            assert len(row["explanation"]) == 2
+            assert len(row["answer"]) == 2
+            
+            # Should contain only the complete parses, skipping the partial one
+            assert row["explanation"] == ["Complete explanation", "Another explanation"]
+            assert row["answer"] == ["Complete answer", "Another answer"]
+            
+            # Verify lists are properly aligned (same indices correspond to same response)
+            assert "Complete" in row["explanation"][0] and "Complete" in row["answer"][0]
+            assert "Another" in row["explanation"][1] and "Another" in row["answer"][1]
+
     def test_non_list_columns_preserved_both_modes(self):
         """Test that non-output columns are preserved with correct types in both expand_lists modes."""
         with patch(

--- a/tests/blocks/llm/test_llm_chat_with_parsing_retry_block.py
+++ b/tests/blocks/llm/test_llm_chat_with_parsing_retry_block.py
@@ -993,17 +993,19 @@ class TestLLMChatWithParsingRetryBlockExpandListsFalse:
             mock_response = MagicMock()
             mock_response.choices = [MagicMock(), MagicMock(), MagicMock()]
             # Response 1: Complete parse (both explanation and answer)
-            mock_response.choices[0].message.content = (
-                "<explanation>Complete explanation</explanation><answer>Complete answer</answer>"
-            )
+            mock_response.choices[
+                0
+            ].message.content = "<explanation>Complete explanation</explanation><answer>Complete answer</answer>"
             # Response 2: Partial parse (only explanation, missing answer)
-            mock_response.choices[1].message.content = (
+            mock_response.choices[
+                1
+            ].message.content = (
                 "<explanation>Partial explanation</explanation>No answer tag here"
             )
             # Response 3: Another complete parse
-            mock_response.choices[2].message.content = (
-                "<explanation>Another explanation</explanation><answer>Another answer</answer>"
-            )
+            mock_response.choices[
+                2
+            ].message.content = "<explanation>Another explanation</explanation><answer>Another answer</answer>"
             mock_completion.return_value = mock_response
 
             block = LLMChatWithParsingRetryBlock(
@@ -1027,17 +1029,19 @@ class TestLLMChatWithParsingRetryBlockExpandListsFalse:
             # Should have 1 row with lists containing only the 2 complete parses
             assert len(result) == 1
             row = result[0]
-            
+
             # Both lists should have exactly 2 items (only complete parses counted)
             assert len(row["explanation"]) == 2
             assert len(row["answer"]) == 2
-            
+
             # Should contain only the complete parses, skipping the partial one
             assert row["explanation"] == ["Complete explanation", "Another explanation"]
             assert row["answer"] == ["Complete answer", "Another answer"]
-            
+
             # Verify lists are properly aligned (same indices correspond to same response)
-            assert "Complete" in row["explanation"][0] and "Complete" in row["answer"][0]
+            assert (
+                "Complete" in row["explanation"][0] and "Complete" in row["answer"][0]
+            )
             assert "Another" in row["explanation"][1] and "Another" in row["answer"][1]
 
     def test_non_list_columns_preserved_both_modes(self):


### PR DESCRIPTION
## Fix retry counting for expand_lists=False in LLMChatWithParsingRetryBlock

### Problem

  The retry logic in LLMChatWithParsingRetryBlock was broken when using
  expand_lists=False. The block would incorrectly count successful parses by using
  len(parsed_result), which always returned 1 when expand_lists=False (since it returns a
   single row with lists as values), regardless of how many individual responses were
  actually parsed successfully. This caused unnecessary retries even when the target
  count was already reached.

### Root Cause

  - When expand_lists=False, TextParserBlock returns exactly 1 row with all parsed
  content as lists in the columns
  - LLMChatWithParsingRetryBlock counted successful parses using len(parsed_result),
  expecting "one row per successful parse"
  - This assumption broke with expand_lists=False, leading to incorrect retry behavior

### Solution

  Implemented separate retry counting logic based on the expand_lists setting:

  When expand_lists=True (existing behavior):
  - Count successful parses by counting result rows: len(parsed_result)
  - Maintains full backward compatibility

  When expand_lists=False (new behavior):
  - Parse each LLM response individually using temporary expand_lists=True
  - Accumulate successful parses into lists for each output column
  - Count the actual number of successful individual parses
  - Return single row with accumulated lists

 ### Key Changes

  1. llm_chat_with_parsing_retry_block.py: Added branching logic to handle both
  expand_lists modes correctly
  2. text_parser_block.py: Removed resolved TODO comment
  3. Added comprehensive tests: 5 new tests covering all critical scenarios for
  expand_lists=False

  ### Testing

  - ✅ All existing tests pass (31 tests) - no regression
  - ✅ 5 new tests for expand_lists=False behavior:
    - Successful parsing on first attempt
    - Partial success requiring retries
    - MaxRetriesExceededError with correct counts
    - Comparison between expand_lists modes
    - Column type preservation for both modes

 ###  Backwards Compatibility

  - ✅ Zero breaking changes
  - ✅ expand_lists=True behavior unchanged
  - ✅ All existing functionality preserved

 ### Example

  Before (broken):
  - With expand_lists=False, n=3
  - Even if all 3 responses parsed successfully, retry block would see len(result)=1
  - and keep retrying unnecessarily

  After (fixed):
  - With expand_lists=False, n=3  
  - Correctly counts 3 successful individual parses
  - Returns 1 row with answer=[parsed1, parsed2, parsed3]
  - No unnecessary retries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Two parsing-retry modes depending on list-expansion setting for better output shaping.
  - New explicit error when retry limits are exceeded (includes target/actual/max info).
  - Ability to view internal component status for troubleshooting and refreshed client handling when configs change.

- Refactor
  - Initialization and dynamic parameter forwarding revamped; improved per-sample processing, validation, logging, and result trimming.

- Tests
  - Expanded tests for non-list mode: success, partial retries, max-retry errors, cross-mode comparisons, type preservation, and runtime overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->