### PR TITLE
Feat/max concurrency

### DIFF
--- a/docs/blocks/llm-blocks.md
+++ b/docs/blocks/llm-blocks.md
@@ -155,7 +155,7 @@ from sdg_hub import Flow
 flow = Flow.from_yaml("path/to/your/flow.yaml")
 flow.set_model_config(model="openai/gpt-4o", api_key="your-key")
 
-# Control concurrency across all LLM blocks in the flow
+# Control concurrency for each LLM block in the flow
 result = flow.generate(
     dataset, 
     max_concurrency=5  # Max 5 concurrent requests at any time

--- a/docs/blocks/llm-blocks.md
+++ b/docs/blocks/llm-blocks.md
@@ -130,7 +130,7 @@ dataset = Dataset.from_dict({
 })
 ```
 
-#### Async Processing
+#### Async Processing & Concurrency Control
 ```python
 chat_block = LLMChatBlock(
     block_name="async_chat",
@@ -143,6 +143,56 @@ chat_block = LLMChatBlock(
 # Automatically handles concurrent API calls for better throughput
 result = chat_block.generate(large_dataset)
 ```
+
+**Flow-Level Concurrency Control:**
+
+When using LLM blocks within flows, you can control concurrency to prevent overwhelming API servers or hitting rate limits:
+
+```python
+from sdg_hub import Flow
+
+# Load a flow with LLM blocks
+flow = Flow.from_yaml("path/to/your/flow.yaml")
+flow.set_model_config(model="openai/gpt-4o", api_key="your-key")
+
+# Control concurrency across all LLM blocks in the flow
+result = flow.generate(
+    dataset, 
+    max_concurrency=5  # Max 5 concurrent requests at any time
+)
+```
+
+**Benefits of Concurrency Control:**
+- **Rate Limit Management** - Prevent API throttling by limiting concurrent requests
+- **Resource Control** - Manage memory and network usage for large datasets  
+- **Provider-Friendly** - Respect API provider recommendations for concurrent requests
+- **Automatic Scaling** - No concurrency limit = maximum parallelism for fastest processing
+
+**How It Works:**
+
+The unified async system automatically detects whether you're processing single or multiple messages and applies concurrency control appropriately:
+
+```python
+# Single message - processed immediately
+single_message = [{"role": "user", "content": "Hello"}]
+
+# Multiple messages - concurrency controlled via semaphore
+batch_messages = [
+    [{"role": "user", "content": "Question 1"}],
+    [{"role": "user", "content": "Question 2"}],
+    [{"role": "user", "content": "Question 3"}],
+    # ... up to thousands of messages
+]
+
+# Both cases use the same unified API under the hood
+# Concurrency is managed transparently
+```
+
+**Performance Guidelines:**
+- **Small datasets (<100 samples)**: No concurrency limit needed
+- **Medium datasets (100-1000 samples)**: `max_concurrency=10-20`
+- **Large datasets (1000+ samples)**: `max_concurrency=5-10` (respect API limits)
+- **Production workloads**: Start conservative and tune based on error rates
 
 ### Message Format
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -159,7 +159,13 @@ Every block validates data at runtime:
 - Watch execution logs for bottlenecks
 - Use async-friendly blocks for LLM operations
 
-### 4. Design for Reuse
+### 4. Optimize for Scale
+- Use `max_concurrency` parameter to control API request rates
+- Start with conservative concurrency limits (5-10) for production
+- Increase concurrency carefully while monitoring error rates
+- Consider provider-specific rate limits and costs
+
+### 5. Design for Reuse
 - Create modular flows that can be combined
 - Use parameters for customization points
 

--- a/docs/flows/overview.md
+++ b/docs/flows/overview.md
@@ -304,7 +304,7 @@ For flows containing LLM blocks, you can control the maximum number of concurren
 # Basic concurrency control
 result = flow.generate(
     dataset,
-    max_concurrency=5  # Max 5 concurrent requests across all LLM blocks
+    max_concurrency=5  # Max 5 concurrent requests per LLM block execution
 )
 
 # Combined with other parameters

--- a/docs/flows/overview.md
+++ b/docs/flows/overview.md
@@ -296,6 +296,51 @@ result = flow.generate(
 )
 ```
 
+### Concurrency Control
+
+For flows containing LLM blocks, you can control the maximum number of concurrent API requests to prevent overwhelming servers or hitting rate limits:
+
+```python
+# Basic concurrency control
+result = flow.generate(
+    dataset,
+    max_concurrency=5  # Max 5 concurrent requests across all LLM blocks
+)
+
+# Combined with other parameters
+result = flow.generate(
+    dataset,
+    max_concurrency=10,
+    runtime_params={
+        "temperature": 0.7,
+        "max_tokens": 200
+    }
+)
+```
+
+**When to Use Concurrency Control:**
+
+- **Large Datasets** - Process thousands of samples without overwhelming APIs
+- **Rate Limit Management** - Respect provider-specific concurrent request limits
+- **Production Workloads** - Ensure stable, predictable resource usage
+- **Cost Optimization** - Prevent burst API charges from uncontrolled parallelism
+
+**Recommended Settings:**
+
+```python
+# Conservative (recommended for production)
+result = flow.generate(dataset, max_concurrency=5)
+
+# Moderate (good for development/testing)  
+result = flow.generate(dataset, max_concurrency=10)
+
+# Aggressive (only for robust APIs and small datasets)
+result = flow.generate(dataset, max_concurrency=20)
+
+# No limit (maximum speed, use with caution)
+result = flow.generate(dataset)  # Default behavior
+```
+
 ## 🚀 Next Steps
 
 Ready to master the flow system? Explore these detailed guides:

--- a/src/sdg_hub/core/blocks/deprecated_blocks/selector.py
+++ b/src/sdg_hub/core/blocks/deprecated_blocks/selector.py
@@ -81,7 +81,7 @@ class SelectorBlock(BaseBlock):
             choice_cols=[choice_col],
         )
 
-    def generate(self, samples: Dataset) -> Dataset:
+    def generate(self, samples: Dataset, **kwargs) -> Dataset:
         """Generate a new dataset with selected values.
 
         Parameters

--- a/src/sdg_hub/core/blocks/llm/client_manager.py
+++ b/src/sdg_hub/core/blocks/llm/client_manager.py
@@ -160,9 +160,69 @@ class LLMClientManager:
             return response.choices[0].message.content
 
     async def acreate_completion(
+        self,
+        messages: Union[list[dict[str, Any]], list[list[dict[str, Any]]]],
+        max_concurrency: Optional[int] = None,
+        **overrides: Any,
+    ) -> Union[str, list[str]]:
+        """Create async completion(s) using LiteLLM with optional concurrency control.
+
+        Parameters
+        ----------
+        messages : Union[List[Dict[str, Any]], List[List[Dict[str, Any]]]]
+            Single message list or list of message lists.
+            - For single: List[Dict[str, Any]] - returns Union[str, List[str]]
+            - For multiple: List[List[Dict[str, Any]]] - returns List[Union[str, List[str]]]
+        max_concurrency : Optional[int], optional
+            Maximum number of concurrent requests when processing multiple messages.
+            If None, all requests run concurrently.
+        **overrides : Any
+            Runtime parameter overrides.
+
+        Returns
+        -------
+        Union[str, List[str]]
+            For single message: completion text (string when n=1, list when n>1)
+            For multiple messages: list of completion texts
+
+        Raises
+        ------
+        Exception
+            If the completion fails after all retries.
+        """
+        # Detect if we have single message or multiple messages
+        if not messages:
+            raise ValueError("messages cannot be empty")
+
+        # Check if first element is a dict (single message) or list (multiple messages)
+        if isinstance(messages[0], dict):
+            # Single message case
+            return await self._acreate_single(messages, **overrides)
+        else:
+            # Multiple messages case
+            messages_list = messages
+
+            if max_concurrency is not None:
+                # Use semaphore for concurrency control
+                semaphore = asyncio.Semaphore(max_concurrency)
+
+                async def _create_with_semaphore(msgs):
+                    async with semaphore:
+                        return await self._acreate_single(msgs, **overrides)
+
+                tasks = [_create_with_semaphore(msgs) for msgs in messages_list]
+                return await asyncio.gather(*tasks)
+            else:
+                # No concurrency limit - process all at once
+                tasks = [
+                    self._acreate_single(msgs, **overrides) for msgs in messages_list
+                ]
+                return await asyncio.gather(*tasks)
+
+    async def _acreate_single(
         self, messages: list[dict[str, Any]], **overrides: Any
     ) -> Union[str, list[str]]:
-        """Create an async completion using LiteLLM.
+        """Create a single async completion using LiteLLM.
 
         Parameters
         ----------
@@ -234,29 +294,6 @@ class LLMClientManager:
             result = self.create_completion(messages, **overrides)
             results.append(result)
         return results
-
-    async def acreate_completions_batch(
-        self, messages_list: list[list[dict[str, Any]]], **overrides: Any
-    ) -> list[Union[str, list[str]]]:
-        """Create multiple completions in batch asynchronously.
-
-        Parameters
-        ----------
-        messages_list : List[List[Dict[str, Any]]]
-            List of message lists to process.
-        **overrides : Any
-            Runtime parameter overrides.
-
-        Returns
-        -------
-        List[Union[str, List[str]]]
-            List of completion texts. Each element is a single string when n=1 or n is None,
-            or a list of strings when n>1.
-        """
-        tasks = [
-            self.acreate_completion(messages, **overrides) for messages in messages_list
-        ]
-        return await asyncio.gather(*tasks)
 
     def _build_completion_kwargs(
         self, messages: list[dict[str, Any]], config: LLMConfig

--- a/src/sdg_hub/core/blocks/llm/client_manager.py
+++ b/src/sdg_hub/core/blocks/llm/client_manager.py
@@ -164,7 +164,7 @@ class LLMClientManager:
         messages: Union[list[dict[str, Any]], list[list[dict[str, Any]]]],
         max_concurrency: Optional[int] = None,
         **overrides: Any,
-    ) -> Union[str, list[str]]:
+    ) -> Union[str, list[str], list[Union[str, list[str]]]]:
         """Create async completion(s) using LiteLLM with optional concurrency control.
 
         Parameters
@@ -181,9 +181,9 @@ class LLMClientManager:
 
         Returns
         -------
-        Union[str, List[str]]
+        Union[str, List[str], List[Union[str, List[str]]]]
             For single message: completion text (string when n=1, list when n>1)
-            For multiple messages: list of completion texts
+            For multiple messages: list of completion texts (each element can be str or List[str])
 
         Raises
         ------

--- a/src/sdg_hub/core/blocks/llm/llm_chat_block.py
+++ b/src/sdg_hub/core/blocks/llm/llm_chat_block.py
@@ -339,7 +339,17 @@ class LLMChatBlock(BaseBlock):
                 "batch_size": len(messages_list),
                 "async_mode": self.async_mode,
                 "flow_max_concurrency": flow_max_concurrency,
-                "override_params": override_kwargs,
+                "override_params": {
+                    k: (
+                        "***"
+                        if any(
+                            s in k.lower()
+                            for s in ["key", "token", "secret", "authorization"]
+                        )
+                        else v
+                    )
+                    for k, v in override_kwargs.items()
+                },
             },
         )
 

--- a/src/sdg_hub/core/blocks/llm/llm_chat_block.py
+++ b/src/sdg_hub/core/blocks/llm/llm_chat_block.py
@@ -298,8 +298,8 @@ class LLMChatBlock(BaseBlock):
             stop, seed, response_format, stream, n, and provider-specific params.
 
             Special flow-level parameters:
-            _flow_semaphore : asyncio.Semaphore, optional
-                Semaphore for controlling concurrency (passed by Flow).
+            _flow_max_concurrency : int, optional
+                Maximum concurrency for async requests (passed by Flow).
 
         Returns
         -------
@@ -318,8 +318,8 @@ class LLMChatBlock(BaseBlock):
                 f"Call flow.set_model_config() before generating."
             )
 
-        # Extract semaphore if provided by flow
-        flow_semaphore = override_kwargs.pop("_flow_semaphore", None)
+        # Extract max_concurrency if provided by flow
+        flow_max_concurrency = override_kwargs.pop("_flow_max_concurrency", None)
 
         # Extract messages
         messages_list = samples[self.input_cols[0]]
@@ -327,23 +327,40 @@ class LLMChatBlock(BaseBlock):
         # Log generation start
         logger.info(
             f"Starting {'async' if self.async_mode else 'sync'} generation for {len(messages_list)} samples"
-            + (" (max_concurrency controlled by flow)" if flow_semaphore else ""),
+            + (
+                f" (max_concurrency={flow_max_concurrency})"
+                if flow_max_concurrency
+                else ""
+            ),
             extra={
                 "block_name": self.block_name,
                 "model": self.model,
                 "provider": self.client_manager.config.get_provider(),
                 "batch_size": len(messages_list),
                 "async_mode": self.async_mode,
-                "has_flow_semaphore": flow_semaphore is not None,
+                "flow_max_concurrency": flow_max_concurrency,
                 "override_params": override_kwargs,
             },
         )
 
         # Generate responses
         if self.async_mode:
-            responses = asyncio.run(
-                self._generate_async(messages_list, flow_semaphore, **override_kwargs)
-            )
+            try:
+                # Check if there's already a running event loop
+                asyncio.get_running_loop()
+            except RuntimeError:
+                # No running loop; safe to create one
+                responses = asyncio.run(
+                    self._generate_async(
+                        messages_list, flow_max_concurrency, **override_kwargs
+                    )
+                )
+            else:
+                # Running inside an event loop, which is not supported
+                raise BlockValidationError(
+                    f"async_mode=True cannot be used from within a running event loop for '{self.block_name}'. "
+                    "Use an async entrypoint or set async_mode=False."
+                )
         else:
             responses = self._generate_sync(messages_list, **override_kwargs)
 
@@ -418,7 +435,7 @@ class LLMChatBlock(BaseBlock):
     async def _generate_async(
         self,
         messages_list: list[list[dict[str, Any]]],
-        flow_semaphore: Optional[Any] = None,
+        flow_max_concurrency: Optional[int] = None,
         **override_kwargs: dict[str, Any],
     ) -> list[Union[str, list[str]]]:
         """Generate responses asynchronously.
@@ -427,8 +444,8 @@ class LLMChatBlock(BaseBlock):
         ----------
         messages_list : List[List[Dict[str, Any]]]
             List of message lists to process.
-        flow_semaphore : Optional[asyncio.Semaphore], optional
-            Semaphore for controlling concurrency.
+        flow_max_concurrency : Optional[int], optional
+            Maximum concurrency for async requests.
         **override_kwargs : Dict[str, Any]
             Runtime parameter overrides.
 
@@ -438,22 +455,10 @@ class LLMChatBlock(BaseBlock):
             List of response strings or lists of response strings (when n > 1).
         """
         try:
-            if flow_semaphore:
-                # Process with semaphore control
-                async def _create_with_semaphore(messages):
-                    async with flow_semaphore:
-                        return await self.client_manager.acreate_completion(
-                            messages, **override_kwargs
-                        )
-
-                # Create tasks for all messages
-                tasks = [_create_with_semaphore(messages) for messages in messages_list]
-                responses = await asyncio.gather(*tasks)
-            else:
-                # Use existing batch method without semaphore
-                responses = await self.client_manager.acreate_completions_batch(
-                    messages_list, **override_kwargs
-                )
+            # Use unified client manager method with optional concurrency control
+            responses = await self.client_manager.acreate_completion(
+                messages_list, max_concurrency=flow_max_concurrency, **override_kwargs
+            )
 
             return responses
 

--- a/src/sdg_hub/core/blocks/llm/llm_chat_block.py
+++ b/src/sdg_hub/core/blocks/llm/llm_chat_block.py
@@ -296,6 +296,10 @@ class LLMChatBlock(BaseBlock):
             Valid parameters depend on the provider but typically include:
             temperature, max_tokens, top_p, frequency_penalty, presence_penalty,
             stop, seed, response_format, stream, n, and provider-specific params.
+            
+            Special flow-level parameters:
+            _flow_semaphore : asyncio.Semaphore, optional
+                Semaphore for controlling concurrency (passed by Flow).
 
         Returns
         -------
@@ -314,18 +318,23 @@ class LLMChatBlock(BaseBlock):
                 f"Call flow.set_model_config() before generating."
             )
 
+        # Extract semaphore if provided by flow
+        flow_semaphore = override_kwargs.pop("_flow_semaphore", None)
+
         # Extract messages
         messages_list = samples[self.input_cols[0]]
 
         # Log generation start
         logger.info(
-            f"Starting {'async' if self.async_mode else 'sync'} generation for {len(messages_list)} samples",
+            f"Starting {'async' if self.async_mode else 'sync'} generation for {len(messages_list)} samples"
+            + (f" (max_concurrency controlled by flow)" if flow_semaphore else ""),
             extra={
                 "block_name": self.block_name,
                 "model": self.model,
                 "provider": self.client_manager.config.get_provider(),
                 "batch_size": len(messages_list),
                 "async_mode": self.async_mode,
+                "has_flow_semaphore": flow_semaphore is not None,
                 "override_params": override_kwargs,
             },
         )
@@ -333,7 +342,7 @@ class LLMChatBlock(BaseBlock):
         # Generate responses
         if self.async_mode:
             responses = asyncio.run(
-                self._generate_async(messages_list, **override_kwargs)
+                self._generate_async(messages_list, flow_semaphore, **override_kwargs)
             )
         else:
             responses = self._generate_sync(messages_list, **override_kwargs)
@@ -409,6 +418,7 @@ class LLMChatBlock(BaseBlock):
     async def _generate_async(
         self,
         messages_list: list[list[dict[str, Any]]],
+        flow_semaphore: Optional[Any] = None,
         **override_kwargs: dict[str, Any],
     ) -> list[Union[str, list[str]]]:
         """Generate responses asynchronously.
@@ -417,6 +427,8 @@ class LLMChatBlock(BaseBlock):
         ----------
         messages_list : List[List[Dict[str, Any]]]
             List of message lists to process.
+        flow_semaphore : Optional[asyncio.Semaphore], optional
+            Semaphore for controlling concurrency.
         **override_kwargs : Dict[str, Any]
             Runtime parameter overrides.
 
@@ -426,9 +438,23 @@ class LLMChatBlock(BaseBlock):
             List of response strings or lists of response strings (when n > 1).
         """
         try:
-            responses = await self.client_manager.acreate_completions_batch(
-                messages_list, **override_kwargs
-            )
+            if flow_semaphore:
+                # Process with semaphore control
+                async def _create_with_semaphore(messages):
+                    async with flow_semaphore:
+                        return await self.client_manager.acreate_completion(
+                            messages, **override_kwargs
+                        )
+                
+                # Create tasks for all messages
+                tasks = [_create_with_semaphore(messages) for messages in messages_list]
+                responses = await asyncio.gather(*tasks)
+            else:
+                # Use existing batch method without semaphore
+                responses = await self.client_manager.acreate_completions_batch(
+                    messages_list, **override_kwargs
+                )
+            
             return responses
 
         except Exception as e:

--- a/src/sdg_hub/core/blocks/llm/llm_chat_block.py
+++ b/src/sdg_hub/core/blocks/llm/llm_chat_block.py
@@ -347,19 +347,33 @@ class LLMChatBlock(BaseBlock):
         if self.async_mode:
             try:
                 # Check if there's already a running event loop
-                asyncio.get_running_loop()
+                loop = asyncio.get_running_loop()
+                # Check if nest_asyncio is applied (allows nested asyncio.run)
+                # Use multiple detection methods for robustness
+                nest_asyncio_applied = (
+                    hasattr(loop, "_nest_patched")
+                    or getattr(asyncio.run, "__module__", "") == "nest_asyncio"
+                )
+
+                if nest_asyncio_applied:
+                    # nest_asyncio is applied, safe to use asyncio.run
+                    responses = asyncio.run(
+                        self._generate_async(
+                            messages_list, flow_max_concurrency, **override_kwargs
+                        )
+                    )
+                else:
+                    # Running inside an event loop without nest_asyncio
+                    raise BlockValidationError(
+                        f"async_mode=True cannot be used from within a running event loop for '{self.block_name}'. "
+                        "Use an async entrypoint, set async_mode=False, or apply nest_asyncio.apply() in notebook environments."
+                    )
             except RuntimeError:
                 # No running loop; safe to create one
                 responses = asyncio.run(
                     self._generate_async(
                         messages_list, flow_max_concurrency, **override_kwargs
                     )
-                )
-            else:
-                # Running inside an event loop, which is not supported
-                raise BlockValidationError(
-                    f"async_mode=True cannot be used from within a running event loop for '{self.block_name}'. "
-                    "Use an async entrypoint or set async_mode=False."
                 )
         else:
             responses = self._generate_sync(messages_list, **override_kwargs)

--- a/src/sdg_hub/core/blocks/llm/llm_chat_block.py
+++ b/src/sdg_hub/core/blocks/llm/llm_chat_block.py
@@ -296,7 +296,7 @@ class LLMChatBlock(BaseBlock):
             Valid parameters depend on the provider but typically include:
             temperature, max_tokens, top_p, frequency_penalty, presence_penalty,
             stop, seed, response_format, stream, n, and provider-specific params.
-            
+
             Special flow-level parameters:
             _flow_semaphore : asyncio.Semaphore, optional
                 Semaphore for controlling concurrency (passed by Flow).
@@ -327,7 +327,7 @@ class LLMChatBlock(BaseBlock):
         # Log generation start
         logger.info(
             f"Starting {'async' if self.async_mode else 'sync'} generation for {len(messages_list)} samples"
-            + (f" (max_concurrency controlled by flow)" if flow_semaphore else ""),
+            + (" (max_concurrency controlled by flow)" if flow_semaphore else ""),
             extra={
                 "block_name": self.block_name,
                 "model": self.model,
@@ -445,7 +445,7 @@ class LLMChatBlock(BaseBlock):
                         return await self.client_manager.acreate_completion(
                             messages, **override_kwargs
                         )
-                
+
                 # Create tasks for all messages
                 tasks = [_create_with_semaphore(messages) for messages in messages_list]
                 responses = await asyncio.gather(*tasks)
@@ -454,7 +454,7 @@ class LLMChatBlock(BaseBlock):
                 responses = await self.client_manager.acreate_completions_batch(
                     messages_list, **override_kwargs
                 )
-            
+
             return responses
 
         except Exception as e:

--- a/src/sdg_hub/core/blocks/transform/index_based_mapper.py
+++ b/src/sdg_hub/core/blocks/transform/index_based_mapper.py
@@ -174,7 +174,7 @@ class IndexBasedMapperBlock(BaseBlock):
             sample[output_col] = sample[source_col]
         return sample
 
-    def generate(self, samples: Dataset) -> Dataset:
+    def generate(self, samples: Dataset, **kwargs) -> Dataset:
         """Generate a new dataset with selected values.
 
         Parameters

--- a/src/sdg_hub/core/flow/base.py
+++ b/src/sdg_hub/core/flow/base.py
@@ -401,7 +401,10 @@ class Flow(BaseModel):
 
         # Validate max_concurrency parameter
         if max_concurrency is not None:
-            if not isinstance(max_concurrency, int):
+            # Explicitly reject boolean values (bool is a subclass of int in Python)
+            if isinstance(max_concurrency, bool) or not isinstance(
+                max_concurrency, int
+            ):
                 raise FlowValidationError(
                     f"max_concurrency must be an int, got {type(max_concurrency).__name__}"
                 )

--- a/src/sdg_hub/core/flow/base.py
+++ b/src/sdg_hub/core/flow/base.py
@@ -355,6 +355,7 @@ class Flow(BaseModel):
         runtime_params: Optional[dict[str, dict[str, Any]]] = None,
         checkpoint_dir: Optional[str] = None,
         save_freq: Optional[int] = None,
+        max_concurrency: Optional[int] = None,
     ) -> Dataset:
         """Execute the flow blocks in sequence to generate data.
 
@@ -376,6 +377,9 @@ class Flow(BaseModel):
         save_freq : Optional[int], optional
             Number of completed samples after which to save a checkpoint.
             If None, only saves final results when checkpointing is enabled.
+        max_concurrency : Optional[int], optional
+            Maximum number of concurrent requests across all blocks.
+            Controls async request concurrency to prevent overwhelming servers.
 
         Returns
         -------
@@ -393,6 +397,12 @@ class Flow(BaseModel):
         if save_freq is not None and save_freq <= 0:
             raise FlowValidationError(
                 f"save_freq must be greater than 0, got {save_freq}"
+            )
+
+        # Validate max_concurrency parameter
+        if max_concurrency is not None and max_concurrency <= 0:
+            raise FlowValidationError(
+                f"max_concurrency must be greater than 0, got {max_concurrency}"
             )
 
         # Validate preconditions
@@ -417,6 +427,13 @@ class Flow(BaseModel):
             raise FlowValidationError(
                 "Dataset validation failed:\n" + "\n".join(dataset_errors)
             )
+
+        # Create semaphore for concurrency control if specified
+        semaphore = None
+        if max_concurrency is not None:
+            import asyncio
+            semaphore = asyncio.Semaphore(max_concurrency)
+            logger.info(f"Created semaphore with max_concurrency={max_concurrency}")
 
         # Initialize checkpointer if enabled
         checkpointer = None
@@ -443,6 +460,7 @@ class Flow(BaseModel):
         logger.info(
             f"Starting flow '{self.metadata.name}' v{self.metadata.version} "
             f"with {len(dataset)} samples across {len(self.blocks)} blocks"
+            + (f" (max_concurrency={max_concurrency})" if max_concurrency else "")
         )
 
         # Merge migrated runtime params with provided ones (provided ones take precedence)
@@ -466,7 +484,7 @@ class Flow(BaseModel):
 
                 # Execute all blocks on this chunk
                 processed_chunk = self._execute_blocks_on_dataset(
-                    chunk_dataset, runtime_params
+                    chunk_dataset, runtime_params, semaphore
                 )
                 all_processed.append(processed_chunk)
 
@@ -490,7 +508,9 @@ class Flow(BaseModel):
 
         else:
             # Process entire dataset at once
-            final_dataset = self._execute_blocks_on_dataset(dataset, runtime_params)
+            final_dataset = self._execute_blocks_on_dataset(
+                dataset, runtime_params, semaphore
+            )
 
             # Save final checkpoint if checkpointing enabled
             if checkpointer:
@@ -513,7 +533,10 @@ class Flow(BaseModel):
         return final_dataset
 
     def _execute_blocks_on_dataset(
-        self, dataset: Dataset, runtime_params: dict[str, dict[str, Any]]
+        self, 
+        dataset: Dataset, 
+        runtime_params: dict[str, dict[str, Any]],
+        semaphore: Optional[Any] = None,
     ) -> Dataset:
         """Execute all blocks in sequence on the given dataset.
 
@@ -523,6 +546,8 @@ class Flow(BaseModel):
             Dataset to process through all blocks.
         runtime_params : Dict[str, Dict[str, Any]]
             Runtime parameters for block execution.
+        semaphore : Optional[asyncio.Semaphore], optional
+            Semaphore for controlling concurrency across blocks.
 
         Returns
         -------
@@ -540,6 +565,10 @@ class Flow(BaseModel):
 
             # Prepare block execution parameters
             block_kwargs = self._prepare_block_kwargs(block, runtime_params)
+            
+            # Add semaphore to block kwargs if provided
+            if semaphore is not None:
+                block_kwargs["_flow_semaphore"] = semaphore
 
             try:
                 # Check if this is a deprecated block and skip validations

--- a/src/sdg_hub/core/flow/base.py
+++ b/src/sdg_hub/core/flow/base.py
@@ -400,10 +400,15 @@ class Flow(BaseModel):
             )
 
         # Validate max_concurrency parameter
-        if max_concurrency is not None and max_concurrency <= 0:
-            raise FlowValidationError(
-                f"max_concurrency must be greater than 0, got {max_concurrency}"
-            )
+        if max_concurrency is not None:
+            if not isinstance(max_concurrency, int):
+                raise FlowValidationError(
+                    f"max_concurrency must be an int, got {type(max_concurrency).__name__}"
+                )
+            if max_concurrency <= 0:
+                raise FlowValidationError(
+                    f"max_concurrency must be greater than 0, got {max_concurrency}"
+                )
 
         # Validate preconditions
         if not self.blocks:
@@ -428,13 +433,9 @@ class Flow(BaseModel):
                 "Dataset validation failed:\n" + "\n".join(dataset_errors)
             )
 
-        # Create semaphore for concurrency control if specified
-        semaphore = None
+        # Log concurrency control if specified
         if max_concurrency is not None:
-            import asyncio
-
-            semaphore = asyncio.Semaphore(max_concurrency)
-            logger.info(f"Created semaphore with max_concurrency={max_concurrency}")
+            logger.info(f"Using max_concurrency={max_concurrency} for LLM requests")
 
         # Initialize checkpointer if enabled
         checkpointer = None
@@ -485,7 +486,7 @@ class Flow(BaseModel):
 
                 # Execute all blocks on this chunk
                 processed_chunk = self._execute_blocks_on_dataset(
-                    chunk_dataset, runtime_params, semaphore
+                    chunk_dataset, runtime_params, max_concurrency
                 )
                 all_processed.append(processed_chunk)
 
@@ -510,7 +511,7 @@ class Flow(BaseModel):
         else:
             # Process entire dataset at once
             final_dataset = self._execute_blocks_on_dataset(
-                dataset, runtime_params, semaphore
+                dataset, runtime_params, max_concurrency
             )
 
             # Save final checkpoint if checkpointing enabled
@@ -537,7 +538,7 @@ class Flow(BaseModel):
         self,
         dataset: Dataset,
         runtime_params: dict[str, dict[str, Any]],
-        semaphore: Optional[Any] = None,
+        max_concurrency: Optional[int] = None,
     ) -> Dataset:
         """Execute all blocks in sequence on the given dataset.
 
@@ -547,8 +548,8 @@ class Flow(BaseModel):
             Dataset to process through all blocks.
         runtime_params : Dict[str, Dict[str, Any]]
             Runtime parameters for block execution.
-        semaphore : Optional[asyncio.Semaphore], optional
-            Semaphore for controlling concurrency across blocks.
+        max_concurrency : Optional[int], optional
+            Maximum concurrency for LLM requests across blocks.
 
         Returns
         -------
@@ -567,9 +568,9 @@ class Flow(BaseModel):
             # Prepare block execution parameters
             block_kwargs = self._prepare_block_kwargs(block, runtime_params)
 
-            # Add semaphore to block kwargs if provided
-            if semaphore is not None:
-                block_kwargs["_flow_semaphore"] = semaphore
+            # Add max_concurrency to block kwargs if provided
+            if max_concurrency is not None:
+                block_kwargs["_flow_max_concurrency"] = max_concurrency
 
             try:
                 # Check if this is a deprecated block and skip validations

--- a/src/sdg_hub/core/flow/base.py
+++ b/src/sdg_hub/core/flow/base.py
@@ -432,6 +432,7 @@ class Flow(BaseModel):
         semaphore = None
         if max_concurrency is not None:
             import asyncio
+
             semaphore = asyncio.Semaphore(max_concurrency)
             logger.info(f"Created semaphore with max_concurrency={max_concurrency}")
 
@@ -533,8 +534,8 @@ class Flow(BaseModel):
         return final_dataset
 
     def _execute_blocks_on_dataset(
-        self, 
-        dataset: Dataset, 
+        self,
+        dataset: Dataset,
         runtime_params: dict[str, dict[str, Any]],
         semaphore: Optional[Any] = None,
     ) -> Dataset:
@@ -565,7 +566,7 @@ class Flow(BaseModel):
 
             # Prepare block execution parameters
             block_kwargs = self._prepare_block_kwargs(block, runtime_params)
-            
+
             # Add semaphore to block kwargs if provided
             if semaphore is not None:
                 block_kwargs["_flow_semaphore"] = semaphore

--- a/tests/flow/test_base.py
+++ b/tests/flow/test_base.py
@@ -1177,68 +1177,68 @@ class TestFlow:
     def test_generate_with_max_concurrency_limit(self):
         """Test that max_concurrency limits concurrent requests."""
         import asyncio
-        
+
         active, max_concurrent = [0], [0]
-        
+
         async def mock_acreate(*args, **kwargs):
             active[0] += 1
             max_concurrent[0] = max(max_concurrent[0], active[0])
             await asyncio.sleep(0.01)
             active[0] -= 1
             return "response"
-        
+
         # Use real LLMChatBlock
         from sdg_hub.core.blocks.llm.llm_chat_block import LLMChatBlock
-        
+
         messages_data = [[{"role": "user", "content": f"test {i}"}] for i in range(10)]
         dataset = Dataset.from_dict({"messages": messages_data})
-        
-        llm_block = LLMChatBlock(
-            block_name="llm_block", 
-            input_cols="messages",
-            output_cols="output",
-            model="test/model",
-            async_mode=True
-        )
-        llm_block.client_manager.acreate_completion = mock_acreate
-        
-        flow = Flow(blocks=[llm_block], metadata=self.test_metadata)
-        flow._model_config_set = True
-        
-        flow.generate(Dataset.from_dict({"messages": messages_data}), max_concurrency=3)
-        assert max_concurrent[0] <= 3
 
-    def test_generate_without_concurrency_limit(self):
-        """Test that without max_concurrency, all requests run concurrently."""
-        import asyncio
-        
-        active, max_concurrent = [0], [0]
-        
-        async def mock_acreate(*args, **kwargs):
-            active[0] += 1
-            max_concurrent[0] = max(max_concurrent[0], active[0])
-            await asyncio.sleep(0.01)
-            active[0] -= 1
-            return "response"
-        
-        # Use real LLMChatBlock instead of MockBlock
-        from sdg_hub.core.blocks.llm.llm_chat_block import LLMChatBlock
-        
-        # Create dataset with messages format (required for LLMChatBlock)
-        messages_data = [[{"role": "user", "content": f"test {i}"}] for i in range(5)]
-        dataset = Dataset.from_dict({"messages": messages_data})
-        
         llm_block = LLMChatBlock(
             block_name="llm_block",
             input_cols="messages",
             output_cols="output",
             model="test/model",
-            async_mode=True
+            async_mode=True,
         )
         llm_block.client_manager.acreate_completion = mock_acreate
-        
+
         flow = Flow(blocks=[llm_block], metadata=self.test_metadata)
         flow._model_config_set = True
-        
+
+        flow.generate(dataset, max_concurrency=3)
+        assert max_concurrent[0] <= 3
+
+    def test_generate_without_concurrency_limit(self):
+        """Test that without max_concurrency, all requests run concurrently."""
+        import asyncio
+
+        active, max_concurrent = [0], [0]
+
+        async def mock_acreate(*args, **kwargs):
+            active[0] += 1
+            max_concurrent[0] = max(max_concurrent[0], active[0])
+            await asyncio.sleep(0.01)
+            active[0] -= 1
+            return "response"
+
+        # Use real LLMChatBlock instead of MockBlock
+        from sdg_hub.core.blocks.llm.llm_chat_block import LLMChatBlock
+
+        # Create dataset with messages format (required for LLMChatBlock)
+        messages_data = [[{"role": "user", "content": f"test {i}"}] for i in range(5)]
+        dataset = Dataset.from_dict({"messages": messages_data})
+
+        llm_block = LLMChatBlock(
+            block_name="llm_block",
+            input_cols="messages",
+            output_cols="output",
+            model="test/model",
+            async_mode=True,
+        )
+        llm_block.client_manager.acreate_completion = mock_acreate
+
+        flow = Flow(blocks=[llm_block], metadata=self.test_metadata)
+        flow._model_config_set = True
+
         flow.generate(dataset)
         assert max_concurrent[0] == 5

--- a/tests/flow/test_base.py
+++ b/tests/flow/test_base.py
@@ -1176,6 +1176,7 @@ class TestFlow:
 
     def test_generate_with_max_concurrency_limit(self):
         """Test that max_concurrency limits concurrent requests."""
+        # Standard
         import asyncio
 
         active, max_concurrent = [0], [0]
@@ -1188,6 +1189,7 @@ class TestFlow:
             return "response"
 
         # Use real LLMChatBlock
+        # First Party
         from sdg_hub.core.blocks.llm.llm_chat_block import LLMChatBlock
 
         messages_data = [[{"role": "user", "content": f"test {i}"}] for i in range(10)]
@@ -1200,7 +1202,7 @@ class TestFlow:
             model="test/model",
             async_mode=True,
         )
-        llm_block.client_manager.acreate_completion = mock_acreate
+        llm_block.client_manager._acreate_single = mock_acreate
 
         flow = Flow(blocks=[llm_block], metadata=self.test_metadata)
         flow._model_config_set = True
@@ -1210,6 +1212,7 @@ class TestFlow:
 
     def test_generate_without_concurrency_limit(self):
         """Test that without max_concurrency, all requests run concurrently."""
+        # Standard
         import asyncio
 
         active, max_concurrent = [0], [0]
@@ -1222,6 +1225,7 @@ class TestFlow:
             return "response"
 
         # Use real LLMChatBlock instead of MockBlock
+        # First Party
         from sdg_hub.core.blocks.llm.llm_chat_block import LLMChatBlock
 
         # Create dataset with messages format (required for LLMChatBlock)
@@ -1235,10 +1239,39 @@ class TestFlow:
             model="test/model",
             async_mode=True,
         )
-        llm_block.client_manager.acreate_completion = mock_acreate
+        llm_block.client_manager._acreate_single = mock_acreate
 
         flow = Flow(blocks=[llm_block], metadata=self.test_metadata)
         flow._model_config_set = True
 
         flow.generate(dataset)
         assert max_concurrent[0] == 5
+
+    def test_generate_max_concurrency_validation(self):
+        """Test that max_concurrency parameter validation works correctly."""
+        # Third Party
+        from datasets import Dataset
+
+        # First Party
+        from sdg_hub.core.utils.error_handling import FlowValidationError
+
+        dataset = Dataset.from_dict(
+            {"messages": [[{"role": "user", "content": "test"}]]}
+        )
+        flow = Flow(blocks=[], metadata=self.test_metadata)
+
+        # Test invalid type
+        with pytest.raises(FlowValidationError, match="max_concurrency must be an int"):
+            flow.generate(dataset, max_concurrency=3.5)
+
+        # Test zero value
+        with pytest.raises(
+            FlowValidationError, match="max_concurrency must be greater than 0"
+        ):
+            flow.generate(dataset, max_concurrency=0)
+
+        # Test negative value
+        with pytest.raises(
+            FlowValidationError, match="max_concurrency must be greater than 0"
+        ):
+            flow.generate(dataset, max_concurrency=-1)

--- a/tests/flow/test_base.py
+++ b/tests/flow/test_base.py
@@ -1173,3 +1173,72 @@ class TestFlow:
             # Verify the blocks are flattened from all categories
             mock_list_blocks.assert_called_once_with()
             mock_get.assert_called_once_with("nonexistent_block")
+
+    def test_generate_with_max_concurrency_limit(self):
+        """Test that max_concurrency limits concurrent requests."""
+        import asyncio
+        
+        active, max_concurrent = [0], [0]
+        
+        async def mock_acreate(*args, **kwargs):
+            active[0] += 1
+            max_concurrent[0] = max(max_concurrent[0], active[0])
+            await asyncio.sleep(0.01)
+            active[0] -= 1
+            return "response"
+        
+        # Use real LLMChatBlock
+        from sdg_hub.core.blocks.llm.llm_chat_block import LLMChatBlock
+        
+        messages_data = [[{"role": "user", "content": f"test {i}"}] for i in range(10)]
+        dataset = Dataset.from_dict({"messages": messages_data})
+        
+        llm_block = LLMChatBlock(
+            block_name="llm_block", 
+            input_cols="messages",
+            output_cols="output",
+            model="test/model",
+            async_mode=True
+        )
+        llm_block.client_manager.acreate_completion = mock_acreate
+        
+        flow = Flow(blocks=[llm_block], metadata=self.test_metadata)
+        flow._model_config_set = True
+        
+        flow.generate(Dataset.from_dict({"messages": messages_data}), max_concurrency=3)
+        assert max_concurrent[0] <= 3
+
+    def test_generate_without_concurrency_limit(self):
+        """Test that without max_concurrency, all requests run concurrently."""
+        import asyncio
+        
+        active, max_concurrent = [0], [0]
+        
+        async def mock_acreate(*args, **kwargs):
+            active[0] += 1
+            max_concurrent[0] = max(max_concurrent[0], active[0])
+            await asyncio.sleep(0.01)
+            active[0] -= 1
+            return "response"
+        
+        # Use real LLMChatBlock instead of MockBlock
+        from sdg_hub.core.blocks.llm.llm_chat_block import LLMChatBlock
+        
+        # Create dataset with messages format (required for LLMChatBlock)
+        messages_data = [[{"role": "user", "content": f"test {i}"}] for i in range(5)]
+        dataset = Dataset.from_dict({"messages": messages_data})
+        
+        llm_block = LLMChatBlock(
+            block_name="llm_block",
+            input_cols="messages",
+            output_cols="output",
+            model="test/model",
+            async_mode=True
+        )
+        llm_block.client_manager.acreate_completion = mock_acreate
+        
+        flow = Flow(blocks=[llm_block], metadata=self.test_metadata)
+        flow._model_config_set = True
+        
+        flow.generate(dataset)
+        assert max_concurrent[0] == 5


### PR DESCRIPTION
Closes [ #368 ]

---
- add max_concurrency to flow.generate
- create semaphore and use it in `LLMChatBlock._generate_async`
- add tests in `tests/flow/test_base.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Flow-level max_concurrency to cap parallel LLM requests across blocks; validated, logged, and propagated through execution.
  - Async LLM client gains concurrency-aware completions with optional per-request limits and improved logging/metadata.
  - Async path improved to detect running event loops and handle async execution safely.

- **Breaking Changes**
  - Async batch helper removed; async completion API now accepts a max_concurrency parameter.

- **Documentation**
  - Docs updated with concurrency control guidance, presets, and examples.

- **Tests**
  - Added tests for capped/unrestricted concurrency and max_concurrency validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->