### PR TITLE
Feat/retain all message contents -- support GPT-OSS

### DIFF
--- a/src/sdg_hub/core/blocks/llm/client_manager.py
+++ b/src/sdg_hub/core/blocks/llm/client_manager.py
@@ -109,7 +109,7 @@ class LLMClientManager:
 
     def create_completion(
         self, messages: list[dict[str, Any]], **overrides: Any
-    ) -> Union[str, list[str]]:
+    ) -> Union[dict, list[dict]]:
         """Create a completion using LiteLLM.
 
         Parameters
@@ -121,9 +121,9 @@ class LLMClientManager:
 
         Returns
         -------
-        Union[str, List[str]]
-            The completion text(s). Returns a single string when n=1 or n is None,
-            returns a list of strings when n>1.
+        Union[dict, List[dict]]
+            The completion response(s). Returns a single response when n=1 or n is None,
+            returns a list of responses when n>1. Response dicts contain 'content' and may contain 'reasoning_content'.
 
         Raises
         ------
@@ -151,28 +151,28 @@ class LLMClientManager:
         # Make the completion call
         response = completion_func(kwargs)
 
-        # Extract content from response
+        # Extract message objects from response
         # Check if n > 1 to determine return type
         n_value = final_config.n or 1
         if n_value > 1:
-            return [choice.message.content for choice in response.choices]
+            return [dict(choice.message) for choice in response.choices]
         else:
-            return response.choices[0].message.content
+            return dict(response.choices[0].message)
 
     async def acreate_completion(
         self,
         messages: Union[list[dict[str, Any]], list[list[dict[str, Any]]]],
         max_concurrency: Optional[int] = None,
         **overrides: Any,
-    ) -> Union[str, list[str], list[Union[str, list[str]]]]:
+    ) -> Union[Any, list[Any], list[Union[Any, list[Any]]]]:
         """Create async completion(s) using LiteLLM with optional concurrency control.
 
         Parameters
         ----------
         messages : Union[List[Dict[str, Any]], List[List[Dict[str, Any]]]]
             Single message list or list of message lists.
-            - For single: List[Dict[str, Any]] - returns Union[str, List[str]]
-            - For multiple: List[List[Dict[str, Any]]] - returns List[Union[str, List[str]]]
+            - For single: List[Dict[str, Any]] - returns Union[Any, List[Any]]
+            - For multiple: List[List[Dict[str, Any]]] - returns List[Union[Any, List[Any]]]
         max_concurrency : Optional[int], optional
             Maximum number of concurrent requests when processing multiple messages.
             If None, all requests run concurrently.
@@ -181,9 +181,9 @@ class LLMClientManager:
 
         Returns
         -------
-        Union[str, List[str], List[Union[str, List[str]]]]
-            For single message: completion text (string when n=1, list when n>1)
-            For multiple messages: list of completion texts (each element can be str or List[str])
+        Union[dict, List[dict], List[Union[dict, List[dict]]]]
+            For single message: completion response (dict when n=1, List[dict] when n>1)
+            For multiple messages: list of completion responses (each element can be dict or List[dict])
 
         Raises
         ------
@@ -221,7 +221,7 @@ class LLMClientManager:
 
     async def _acreate_single(
         self, messages: list[dict[str, Any]], **overrides: Any
-    ) -> Union[str, list[str]]:
+    ) -> Union[dict, list[dict]]:
         """Create a single async completion using LiteLLM.
 
         Parameters
@@ -233,10 +233,9 @@ class LLMClientManager:
 
         Returns
         -------
-        Union[str, List[str]]
-            The completion text(s). Returns a single string when n=1 or n is None,
-            returns a list of strings when n>1.
-
+        Union[dict, List[dict]]
+            List of completion message objects. Each element is a dict when n=1 or n is None,
+            or a list of dicts when n>1. Message dicts contain 'content' and may contain 'reasoning_content'.
         Raises
         ------
         Exception
@@ -263,17 +262,17 @@ class LLMClientManager:
         # Make the async completion call
         response = await completion_func(kwargs)
 
-        # Extract content from response
+        # Extract message objects from response
         # Check if n > 1 to determine return type
         n_value = final_config.n or 1
         if n_value > 1:
-            return [choice.message.content for choice in response.choices]
+            return [dict(choice.message) for choice in response.choices]
         else:
-            return response.choices[0].message.content
+            return dict(response.choices[0].message)
 
     def create_completions_batch(
         self, messages_list: list[list[dict[str, Any]]], **overrides: Any
-    ) -> list[Union[str, list[str]]]:
+    ) -> list[Union[dict, list[dict]]]:
         """Create multiple completions in batch.
 
         Parameters
@@ -285,9 +284,9 @@ class LLMClientManager:
 
         Returns
         -------
-        List[Union[str, List[str]]]
-            List of completion texts. Each element is a single string when n=1 or n is None,
-            or a list of strings when n>1.
+        List[dict] | List[List[dict]]
+            List of completion message objects. Each element is a dict when n=1 or n is None,
+            or a list of dicts when n>1. Message dicts contain 'content' and may contain 'reasoning_content'.
         """
         results = []
         for messages in messages_list:

--- a/src/sdg_hub/core/blocks/llm/client_manager.py
+++ b/src/sdg_hub/core/blocks/llm/client_manager.py
@@ -115,8 +115,7 @@ class LLMClientManager:
             return message.__dict__
         else:
             return dict(message)
-    
-        
+
     def create_completion(
         self, messages: list[dict[str, Any]], **overrides: Any
     ) -> Union[dict, list[dict]]:
@@ -165,7 +164,9 @@ class LLMClientManager:
         # Check if n > 1 to determine return type
         n_value = final_config.n or 1
         if n_value > 1:
-            return [self._message_to_dict(choice.message) for choice in response.choices]
+            return [
+                self._message_to_dict(choice.message) for choice in response.choices
+            ]
         else:
             return self._message_to_dict(response.choices[0].message)
 
@@ -276,7 +277,9 @@ class LLMClientManager:
         # Check if n > 1 to determine return type
         n_value = final_config.n or 1
         if n_value > 1:
-            return [self._message_to_dict(choice.message) for choice in response.choices]
+            return [
+                self._message_to_dict(choice.message) for choice in response.choices
+            ]
         else:
             return self._message_to_dict(response.choices[0].message)
 

--- a/src/sdg_hub/core/blocks/llm/client_manager.py
+++ b/src/sdg_hub/core/blocks/llm/client_manager.py
@@ -284,7 +284,7 @@ class LLMClientManager:
 
         Returns
         -------
-        List[dict] | List[List[dict]]   
+        List[dict] | List[List[dict]]
             List of completion responses. Each element is a dict when n=1 or n is None,
             or a list of dicts when n>1. Response dicts contain 'content' and may contain 'reasoning_content'.
         """

--- a/src/sdg_hub/core/blocks/llm/client_manager.py
+++ b/src/sdg_hub/core/blocks/llm/client_manager.py
@@ -164,7 +164,7 @@ class LLMClientManager:
         messages: Union[list[dict[str, Any]], list[list[dict[str, Any]]]],
         max_concurrency: Optional[int] = None,
         **overrides: Any,
-    ) -> Union[Any, list[Any], list[Union[Any, list[Any]]]]:
+    ) -> Union[dict, list[dict]] | list[Union[dict, list[dict]]]:
         """Create async completion(s) using LiteLLM with optional concurrency control.
 
         Parameters
@@ -284,9 +284,9 @@ class LLMClientManager:
 
         Returns
         -------
-        List[dict] | List[List[dict]]
-            List of completion message objects. Each element is a dict when n=1 or n is None,
-            or a list of dicts when n>1. Message dicts contain 'content' and may contain 'reasoning_content'.
+        List[dict] | List[List[dict]]   
+            List of completion responses. Each element is a dict when n=1 or n is None,
+            or a list of dicts when n>1. Response dicts contain 'content' and may contain 'reasoning_content'.
         """
         results = []
         for messages in messages_list:

--- a/src/sdg_hub/core/blocks/llm/client_manager.py
+++ b/src/sdg_hub/core/blocks/llm/client_manager.py
@@ -107,6 +107,16 @@ class LLMClientManager:
                 f"Could not validate setup for model '{self.config.model}': {e}"
             )
 
+    def _message_to_dict(self, message: Any) -> dict[str, Any]:
+        """Convert a message to a dict."""
+        if hasattr(message, "to_dict"):
+            return message.to_dict()
+        elif hasattr(message, "__dict__"):
+            return message.__dict__
+        else:
+            return dict(message)
+    
+        
     def create_completion(
         self, messages: list[dict[str, Any]], **overrides: Any
     ) -> Union[dict, list[dict]]:
@@ -155,9 +165,9 @@ class LLMClientManager:
         # Check if n > 1 to determine return type
         n_value = final_config.n or 1
         if n_value > 1:
-            return [dict(choice.message) for choice in response.choices]
+            return [self._message_to_dict(choice.message) for choice in response.choices]
         else:
-            return dict(response.choices[0].message)
+            return self._message_to_dict(response.choices[0].message)
 
     async def acreate_completion(
         self,
@@ -266,9 +276,9 @@ class LLMClientManager:
         # Check if n > 1 to determine return type
         n_value = final_config.n or 1
         if n_value > 1:
-            return [dict(choice.message) for choice in response.choices]
+            return [self._message_to_dict(choice.message) for choice in response.choices]
         else:
-            return dict(response.choices[0].message)
+            return self._message_to_dict(response.choices[0].message)
 
     def create_completions_batch(
         self, messages_list: list[list[dict[str, Any]]], **overrides: Any

--- a/src/sdg_hub/core/blocks/llm/llm_chat_block.py
+++ b/src/sdg_hub/core/blocks/llm/llm_chat_block.py
@@ -42,9 +42,10 @@ class LLMChatBlock(BaseBlock):
         Name of the block.
     input_cols : Union[str, List[str]]
         Input column name(s). Should contain the messages list.
-    output_cols : Union[str, List[str]]
+    output_cols : Union[dict, List[dict]]
         Output column name(s) for the response. When n > 1, the column will contain
-        a list of responses instead of a single string.
+        a list of responses instead of a single response. Responses contain 'content', 
+        may contain 'reasoning_content' and other fields if any.
     model : str
         Model identifier in LiteLLM format. Examples:
         - "openai/gpt-4"
@@ -131,7 +132,7 @@ class LLMChatBlock(BaseBlock):
     >>> block = LLMChatBlock(
     ...     block_name="gpt4_multiple",
     ...     input_cols="messages",
-    ...     output_cols="responses",  # Will contain lists of strings
+    ...     output_cols="responses",  # Will contain lists of responses
     ...     model="openai/gpt-4",
     ...     n=3,  # Generate 3 responses per input
     ...     temperature=0.8
@@ -406,7 +407,7 @@ class LLMChatBlock(BaseBlock):
         self,
         messages_list: list[list[dict[str, Any]]],
         **override_kwargs: dict[str, Any],
-    ) -> list[Union[str, list[str]]]:
+    ) -> list[Union[dict, list[dict]]]:
         """Generate responses synchronously.
 
         Parameters
@@ -418,8 +419,9 @@ class LLMChatBlock(BaseBlock):
 
         Returns
         -------
-        List[Union[str, List[str]]]
-            List of response strings or lists of response strings (when n > 1).
+        List[Union[dict, List[dict]]]
+            List of responses. Each element is a dict when n=1 or n is None,
+            or a list of dicts when n>1. Response dicts contain 'content', may contain 'reasoning_content' and other fields if any.
         """
         responses = []
 
@@ -461,7 +463,7 @@ class LLMChatBlock(BaseBlock):
         messages_list: list[list[dict[str, Any]]],
         flow_max_concurrency: Optional[int] = None,
         **override_kwargs: dict[str, Any],
-    ) -> list[Union[str, list[str]]]:
+    ) -> list[Union[dict, list[dict]]]:
         """Generate responses asynchronously.
 
         Parameters
@@ -475,8 +477,9 @@ class LLMChatBlock(BaseBlock):
 
         Returns
         -------
-        List[Union[str, List[str]]]
-            List of response strings or lists of response strings (when n > 1).
+        List[Union[dict, List[dict]]]
+            List of responses. Each element is a dict when n=1 or n is None,
+            or a list of dicts when n>1. Response dicts contain 'content', may contain 'reasoning_content' and other fields if any.
         """
         try:
             # Use unified client manager method with optional concurrency control

--- a/src/sdg_hub/core/blocks/llm/llm_chat_block.py
+++ b/src/sdg_hub/core/blocks/llm/llm_chat_block.py
@@ -44,7 +44,7 @@ class LLMChatBlock(BaseBlock):
         Input column name(s). Should contain the messages list.
     output_cols : Union[dict, List[dict]]
         Output column name(s) for the response. When n > 1, the column will contain
-        a list of responses instead of a single response. Responses contain 'content', 
+        a list of responses instead of a single response. Responses contain 'content',
         may contain 'reasoning_content' and other fields if any.
     model : str
         Model identifier in LiteLLM format. Examples:

--- a/src/sdg_hub/core/blocks/llm/text_parser_block.py
+++ b/src/sdg_hub/core/blocks/llm/text_parser_block.py
@@ -51,7 +51,10 @@ class TextParserBlock(BaseBlock):
     expand_lists : bool
         Whether to expand list inputs into individual rows (True) or preserve lists (False).
         Default is True for backward compatibility.
-    
+    save_reasoning_content : bool
+        Whether to save the reasoning content to the output.
+    reasoning_content_field : Optional[str]
+        The field name of the reasoning content to save to the output.
     """
 
     start_tags: list[str] = Field(
@@ -69,6 +72,14 @@ class TextParserBlock(BaseBlock):
     expand_lists: bool = Field(
         default=True,
         description="Whether to expand list inputs into individual rows (True) or preserve lists (False). ",
+    )
+    save_reasoning_content: bool = Field(
+        default=False,
+        description="Whether to save the reasoning content to the output.",
+    )
+    reasoning_content_field: Optional[str] = Field(
+        default='reasoning_content',
+        description="The field name of the reasoning content to save to the output.",
     )
 
     @field_validator("start_tags", "end_tags", mode="before")
@@ -236,23 +247,25 @@ class TextParserBlock(BaseBlock):
         return value
 
     
-    def _handle_message_object(self, sample: Any) -> dict:
-        return self._parse(sample['content'])
-        
+    def _handle_message(self, sample: dict) -> dict[str, list[str]]:
+        parsed_output = self._parse(sample['content'])
+        if self.save_reasoning_content:
+            parsed_output[self.reasoning_content_field] = self._get_reasoning_content(sample)
+        return parsed_output
     
-    def _handle_message(self, sample: Any) -> dict[str, list[str]]:
-        if isinstance(sample, str):
-            return self._parse(sample['content'])
-        elif isinstance(sample, object):
-            return self._handle_message_object(sample)
-        else:
-            logger.warning(f"Invalid message type: {type(sample)}")
-        return {}        
+    def _get_reasoning_content(self, sample: dict) -> str:
+        if self.save_reasoning_content:
+            if self.reasoning_content_field in sample:
+                return sample[self.reasoning_content_field]
+            else:
+                logger.warning(f"Reasoning content field '{self.reasoning_content_field}' not found in response")
+                return ""
+            
         
-
     def _generate(self, sample: dict) -> list[dict]:
         input_column = self.input_cols[0]
         raw_output = sample[input_column]
+        
 
         # Handle list inputs (e.g., from LLMChatBlock with n > 1)
         if isinstance(raw_output, list):
@@ -272,8 +285,10 @@ class TextParserBlock(BaseBlock):
                             f"List item {i} in column '{input_column}' is empty"
                         )
                         continue
+                    
                     parsed_outputs = self._handle_message(message)
-                    # parsed_outputs = self._parse(response)
+                    if self.save_reasoning_content:
+                        reasoning_content = parsed_outputs.pop(self.reasoning_content_field)
 
                     if not parsed_outputs or not any(
                         len(value) > 0 for value in parsed_outputs.values()
@@ -288,6 +303,8 @@ class TextParserBlock(BaseBlock):
                     # Collect all parsed values for each column as lists
                     for col in self.output_cols:
                         all_parsed_outputs[col].extend(parsed_outputs.get(col, []))
+                    if self.save_reasoning_content:
+                        all_parsed_outputs[self.block_name + '_' + self.reasoning_content_field].append(reasoning_content)
 
                 if valid_responses == 0:
                     return []
@@ -305,8 +322,9 @@ class TextParserBlock(BaseBlock):
                         )
                         continue
 
-                    # parsed_outputs = self._parse(message)
                     parsed_outputs = self._handle_message(message)
+                    if self.save_reasoning_content:
+                        reasoning_content = parsed_outputs.pop(self.reasoning_content_field)
 
                     if not parsed_outputs or not any(
                         len(value) > 0 for value in parsed_outputs.values()
@@ -322,9 +340,11 @@ class TextParserBlock(BaseBlock):
                     for values in zip(
                         *(lst[:max_length] for lst in parsed_outputs.values())
                     ):
-                        all_results.append(
-                            {**sample, **dict(zip(parsed_outputs.keys(), values))}
-                        )
+                        result_row = {**sample, **dict(zip(parsed_outputs.keys(), values))}
+                        if self.save_reasoning_content:
+                            result_row[self.block_name + '_' + self.reasoning_content_field] = reasoning_content
+                        all_results.append(result_row)
+                        
 
                 return all_results
 
@@ -333,8 +353,10 @@ class TextParserBlock(BaseBlock):
             if not raw_output:
                 logger.warning(f"Input column '{input_column}' contains empty string")
                 return []
-
             parsed_outputs = self._handle_message(raw_output)
+            if self.save_reasoning_content:
+                reasoning_content = parsed_outputs.pop(self.reasoning_content_field)
+
 
             if not parsed_outputs or not any(
                 len(value) > 0 for value in parsed_outputs.values()
@@ -348,7 +370,12 @@ class TextParserBlock(BaseBlock):
             result = []
             max_length = max(len(value) for value in parsed_outputs.values())
             for values in zip(*(lst[:max_length] for lst in parsed_outputs.values())):
-                result.append({**sample, **dict(zip(parsed_outputs.keys(), values))})
+                result_row = {**sample, **dict(zip(parsed_outputs.keys(), values))}
+                if self.save_reasoning_content:
+                    result_row[self.block_name + '_' + self.reasoning_content_field] = reasoning_content
+                result.append(result_row)
+                
+                
             return result
 
         else:

--- a/src/sdg_hub/core/blocks/llm/text_parser_block.py
+++ b/src/sdg_hub/core/blocks/llm/text_parser_block.py
@@ -252,9 +252,9 @@ class TextParserBlock(BaseBlock):
             return {}
         parsed_output = self._parse(sample["content"])
         if self.save_reasoning_content:
-            parsed_output[self.reasoning_content_field] = self._get_reasoning_content(
+            parsed_output[self.reasoning_content_field] = [self._get_reasoning_content(
                 sample
-            )
+            )]
         return parsed_output
 
     def _get_reasoning_content(self, sample: dict) -> str:
@@ -319,7 +319,7 @@ class TextParserBlock(BaseBlock):
                             ] = []
                         all_parsed_outputs[
                             self.block_name + "_" + self.reasoning_content_field
-                        ].append(reasoning_content)
+                        ].extend(reasoning_content)
 
                 if valid_responses == 0:
                     return []
@@ -362,10 +362,9 @@ class TextParserBlock(BaseBlock):
                             **dict(zip(parsed_outputs.keys(), values)),
                         }
                         if self.save_reasoning_content:
-                            result_row[
-                                self.block_name + "_" + self.reasoning_content_field
-                            ] = reasoning_content
+                            result_row[self.block_name + "_" + self.reasoning_content_field] = reasoning_content[0]
                         all_results.append(result_row)
+                        
 
                 return all_results
 
@@ -393,9 +392,7 @@ class TextParserBlock(BaseBlock):
             for values in zip(*(lst[:max_length] for lst in parsed_outputs.values())):
                 result_row = {**sample, **dict(zip(parsed_outputs.keys(), values))}
                 if self.save_reasoning_content:
-                    result_row[self.block_name + "_" + self.reasoning_content_field] = (
-                        reasoning_content
-                    )
+                    result_row[self.block_name + "_" + self.reasoning_content_field] = reasoning_content[0]
                 result.append(result_row)
 
             return result

--- a/src/sdg_hub/core/blocks/llm/text_parser_block.py
+++ b/src/sdg_hub/core/blocks/llm/text_parser_block.py
@@ -78,7 +78,7 @@ class TextParserBlock(BaseBlock):
         description="Whether to save the reasoning content to the output.",
     )
     reasoning_content_field: Optional[str] = Field(
-        default='reasoning_content',
+        default="reasoning_content",
         description="The field name of the reasoning content to save to the output.",
     )
 
@@ -246,33 +246,34 @@ class TextParserBlock(BaseBlock):
                 value = value.replace(clean_tag, "")
         return value
 
-    
     def _handle_message(self, sample: dict) -> dict[str, list[str]]:
-        parsed_output = self._parse(sample['content'])
+        parsed_output = self._parse(sample["content"])
         if self.save_reasoning_content:
-            parsed_output[self.reasoning_content_field] = self._get_reasoning_content(sample)
+            parsed_output[self.reasoning_content_field] = self._get_reasoning_content(
+                sample
+            )
         return parsed_output
-    
+
     def _get_reasoning_content(self, sample: dict) -> str:
         if self.save_reasoning_content:
             if self.reasoning_content_field in sample:
                 return sample[self.reasoning_content_field]
             else:
-                logger.warning(f"Reasoning content field '{self.reasoning_content_field}' not found in response")
+                logger.warning(
+                    f"Reasoning content field '{self.reasoning_content_field}' not found in response"
+                )
                 return ""
-            
-        
+
     def _generate(self, sample: dict) -> list[dict]:
         input_column = self.input_cols[0]
         raw_output = sample[input_column]
-        
 
         # Handle list inputs (e.g., from LLMChatBlock with n > 1)
         if isinstance(raw_output, list):
             if not raw_output:
                 logger.warning(f"Input column '{input_column}' contains empty list")
                 return []
-            
+
             if not self.expand_lists:
                 # When expand_lists=False, preserve the list structure
                 # Parse each response in the list and collect results as lists
@@ -285,10 +286,12 @@ class TextParserBlock(BaseBlock):
                             f"List item {i} in column '{input_column}' is empty"
                         )
                         continue
-                    
+
                     parsed_outputs = self._handle_message(message)
                     if self.save_reasoning_content:
-                        reasoning_content = parsed_outputs.pop(self.reasoning_content_field)
+                        reasoning_content = parsed_outputs.pop(
+                            self.reasoning_content_field
+                        )
 
                     if not parsed_outputs or not any(
                         len(value) > 0 for value in parsed_outputs.values()
@@ -304,9 +307,16 @@ class TextParserBlock(BaseBlock):
                     for col in self.output_cols:
                         all_parsed_outputs[col].extend(parsed_outputs.get(col, []))
                     if self.save_reasoning_content:
-                        if self.block_name + '_' + self.reasoning_content_field not in all_parsed_outputs:
-                            all_parsed_outputs[self.block_name + '_' + self.reasoning_content_field] = []
-                        all_parsed_outputs[self.block_name + '_' + self.reasoning_content_field].append(reasoning_content)
+                        if (
+                            self.block_name + "_" + self.reasoning_content_field
+                            not in all_parsed_outputs
+                        ):
+                            all_parsed_outputs[
+                                self.block_name + "_" + self.reasoning_content_field
+                            ] = []
+                        all_parsed_outputs[
+                            self.block_name + "_" + self.reasoning_content_field
+                        ].append(reasoning_content)
 
                 if valid_responses == 0:
                     return []
@@ -326,7 +336,9 @@ class TextParserBlock(BaseBlock):
 
                     parsed_outputs = self._handle_message(message)
                     if self.save_reasoning_content:
-                        reasoning_content = parsed_outputs.pop(self.reasoning_content_field)
+                        reasoning_content = parsed_outputs.pop(
+                            self.reasoning_content_field
+                        )
 
                     if not parsed_outputs or not any(
                         len(value) > 0 for value in parsed_outputs.values()
@@ -342,11 +354,15 @@ class TextParserBlock(BaseBlock):
                     for values in zip(
                         *(lst[:max_length] for lst in parsed_outputs.values())
                     ):
-                        result_row = {**sample, **dict(zip(parsed_outputs.keys(), values))}
+                        result_row = {
+                            **sample,
+                            **dict(zip(parsed_outputs.keys(), values)),
+                        }
                         if self.save_reasoning_content:
-                            result_row[self.block_name + '_' + self.reasoning_content_field] = reasoning_content
+                            result_row[
+                                self.block_name + "_" + self.reasoning_content_field
+                            ] = reasoning_content
                         all_results.append(result_row)
-                        
 
                 return all_results
 
@@ -355,11 +371,10 @@ class TextParserBlock(BaseBlock):
             if not raw_output:
                 logger.warning(f"Input column '{input_column}' contains empty dict")
                 return []
-            
+
             parsed_outputs = self._handle_message(raw_output)
             if self.save_reasoning_content:
                 reasoning_content = parsed_outputs.pop(self.reasoning_content_field)
-
 
             if not parsed_outputs or not any(
                 len(value) > 0 for value in parsed_outputs.values()
@@ -375,10 +390,11 @@ class TextParserBlock(BaseBlock):
             for values in zip(*(lst[:max_length] for lst in parsed_outputs.values())):
                 result_row = {**sample, **dict(zip(parsed_outputs.keys(), values))}
                 if self.save_reasoning_content:
-                    result_row[self.block_name + '_' + self.reasoning_content_field] = reasoning_content
+                    result_row[self.block_name + "_" + self.reasoning_content_field] = (
+                        reasoning_content
+                    )
                 result.append(result_row)
-                
-                
+
             return result
 
         else:

--- a/src/sdg_hub/core/blocks/llm/text_parser_block.py
+++ b/src/sdg_hub/core/blocks/llm/text_parser_block.py
@@ -78,7 +78,7 @@ class TextParserBlock(BaseBlock):
         description="Whether to save the reasoning content to the output.",
     )
     reasoning_content_field: Optional[str] = Field(
-        default='reasoning_content',
+        default="reasoning_content",
         description="The field name of the reasoning content to save to the output.",
     )
 
@@ -246,33 +246,35 @@ class TextParserBlock(BaseBlock):
                 value = value.replace(clean_tag, "")
         return value
 
-    
     def _handle_message(self, sample: dict) -> dict[str, list[str]]:
-        parsed_output = self._parse(sample['content'])
+        parsed_output = self._parse(sample["content"])
+
         if self.save_reasoning_content:
-            parsed_output[self.reasoning_content_field] = self._get_reasoning_content(sample)
+            parsed_output[self.reasoning_content_field] = self._get_reasoning_content(
+                sample
+            )
         return parsed_output
-    
+
     def _get_reasoning_content(self, sample: dict) -> str:
         if self.save_reasoning_content:
             if self.reasoning_content_field in sample:
                 return sample[self.reasoning_content_field]
             else:
-                logger.warning(f"Reasoning content field '{self.reasoning_content_field}' not found in response")
+                logger.warning(
+                    f"Reasoning content field '{self.reasoning_content_field}' not found in response"
+                )
                 return ""
-            
-        
+
     def _generate(self, sample: dict) -> list[dict]:
         input_column = self.input_cols[0]
         raw_output = sample[input_column]
-        
 
         # Handle list inputs (e.g., from LLMChatBlock with n > 1)
         if isinstance(raw_output, list):
             if not raw_output:
                 logger.warning(f"Input column '{input_column}' contains empty list")
                 return []
-            
+
             if not self.expand_lists:
                 # When expand_lists=False, preserve the list structure
                 # Parse each response in the list and collect results as lists
@@ -285,10 +287,12 @@ class TextParserBlock(BaseBlock):
                             f"List item {i} in column '{input_column}' is empty"
                         )
                         continue
-                    
+
                     parsed_outputs = self._handle_message(message)
                     if self.save_reasoning_content:
-                        reasoning_content = parsed_outputs.pop(self.reasoning_content_field)
+                        reasoning_content = parsed_outputs.pop(
+                            self.reasoning_content_field
+                        )
 
                     if not parsed_outputs or not any(
                         len(value) > 0 for value in parsed_outputs.values()
@@ -304,7 +308,9 @@ class TextParserBlock(BaseBlock):
                     for col in self.output_cols:
                         all_parsed_outputs[col].extend(parsed_outputs.get(col, []))
                     if self.save_reasoning_content:
-                        all_parsed_outputs[self.block_name + '_' + self.reasoning_content_field].append(reasoning_content)
+                        all_parsed_outputs[
+                            self.block_name + "_" + self.reasoning_content_field
+                        ].append(reasoning_content)
 
                 if valid_responses == 0:
                     return []
@@ -324,7 +330,9 @@ class TextParserBlock(BaseBlock):
 
                     parsed_outputs = self._handle_message(message)
                     if self.save_reasoning_content:
-                        reasoning_content = parsed_outputs.pop(self.reasoning_content_field)
+                        reasoning_content = parsed_outputs.pop(
+                            self.reasoning_content_field
+                        )
 
                     if not parsed_outputs or not any(
                         len(value) > 0 for value in parsed_outputs.values()
@@ -340,11 +348,15 @@ class TextParserBlock(BaseBlock):
                     for values in zip(
                         *(lst[:max_length] for lst in parsed_outputs.values())
                     ):
-                        result_row = {**sample, **dict(zip(parsed_outputs.keys(), values))}
+                        result_row = {
+                            **sample,
+                            **dict(zip(parsed_outputs.keys(), values)),
+                        }
                         if self.save_reasoning_content:
-                            result_row[self.block_name + '_' + self.reasoning_content_field] = reasoning_content
+                            result_row[
+                                self.block_name + "_" + self.reasoning_content_field
+                            ] = reasoning_content
                         all_results.append(result_row)
-                        
 
                 return all_results
 
@@ -353,10 +365,10 @@ class TextParserBlock(BaseBlock):
             if not raw_output:
                 logger.warning(f"Input column '{input_column}' contains empty string")
                 return []
+
             parsed_outputs = self._handle_message(raw_output)
             if self.save_reasoning_content:
                 reasoning_content = parsed_outputs.pop(self.reasoning_content_field)
-
 
             if not parsed_outputs or not any(
                 len(value) > 0 for value in parsed_outputs.values()
@@ -372,10 +384,11 @@ class TextParserBlock(BaseBlock):
             for values in zip(*(lst[:max_length] for lst in parsed_outputs.values())):
                 result_row = {**sample, **dict(zip(parsed_outputs.keys(), values))}
                 if self.save_reasoning_content:
-                    result_row[self.block_name + '_' + self.reasoning_content_field] = reasoning_content
+                    result_row[self.block_name + "_" + self.reasoning_content_field] = (
+                        reasoning_content
+                    )
                 result.append(result_row)
-                
-                
+
             return result
 
         else:

--- a/src/sdg_hub/core/blocks/llm/text_parser_block.py
+++ b/src/sdg_hub/core/blocks/llm/text_parser_block.py
@@ -252,9 +252,9 @@ class TextParserBlock(BaseBlock):
             return {}
         parsed_output = self._parse(sample["content"])
         if self.save_reasoning_content:
-            parsed_output[self.reasoning_content_field] = [self._get_reasoning_content(
-                sample
-            )]
+            parsed_output[self.reasoning_content_field] = [
+                self._get_reasoning_content(sample)
+            ]
         return parsed_output
 
     def _get_reasoning_content(self, sample: dict) -> str:
@@ -362,9 +362,10 @@ class TextParserBlock(BaseBlock):
                             **dict(zip(parsed_outputs.keys(), values)),
                         }
                         if self.save_reasoning_content:
-                            result_row[self.block_name + "_" + self.reasoning_content_field] = reasoning_content[0]
+                            result_row[
+                                self.block_name + "_" + self.reasoning_content_field
+                            ] = reasoning_content[0]
                         all_results.append(result_row)
-                        
 
                 return all_results
 
@@ -392,7 +393,9 @@ class TextParserBlock(BaseBlock):
             for values in zip(*(lst[:max_length] for lst in parsed_outputs.values())):
                 result_row = {**sample, **dict(zip(parsed_outputs.keys(), values))}
                 if self.save_reasoning_content:
-                    result_row[self.block_name + "_" + self.reasoning_content_field] = reasoning_content[0]
+                    result_row[self.block_name + "_" + self.reasoning_content_field] = (
+                        reasoning_content[0]
+                    )
                 result.append(result_row)
 
             return result

--- a/src/sdg_hub/core/blocks/llm/text_parser_block.py
+++ b/src/sdg_hub/core/blocks/llm/text_parser_block.py
@@ -51,6 +51,7 @@ class TextParserBlock(BaseBlock):
     expand_lists : bool
         Whether to expand list inputs into individual rows (True) or preserve lists (False).
         Default is True for backward compatibility.
+    
     """
 
     start_tags: list[str] = Field(
@@ -234,6 +235,21 @@ class TextParserBlock(BaseBlock):
                 value = value.replace(clean_tag, "")
         return value
 
+    
+    def _handle_message_object(self, sample: Any) -> dict:
+        return self._parse(sample['content'])
+        
+    
+    def _handle_message(self, sample: Any) -> dict[str, list[str]]:
+        if isinstance(sample, str):
+            return self._parse(sample['content'])
+        elif isinstance(sample, object):
+            return self._handle_message_object(sample)
+        else:
+            logger.warning(f"Invalid message type: {type(sample)}")
+        return {}        
+        
+
     def _generate(self, sample: dict) -> list[dict]:
         input_column = self.input_cols[0]
         raw_output = sample[input_column]
@@ -243,28 +259,27 @@ class TextParserBlock(BaseBlock):
             if not raw_output:
                 logger.warning(f"Input column '{input_column}' contains empty list")
                 return []
-
+            
             if not self.expand_lists:
                 # When expand_lists=False, preserve the list structure
                 # Parse each response in the list and collect results as lists
                 all_parsed_outputs = {col: [] for col in self.output_cols}
                 valid_responses = 0
 
-                for i, response in enumerate(raw_output):
-                    if not response or not isinstance(response, str):
+                for i, message in enumerate(raw_output):
+                    if not message:
                         logger.warning(
-                            f"List item {i} in column '{input_column}' contains invalid data "
-                            f"(empty or non-string): {type(response)}"
+                            f"List item {i} in column '{input_column}' is empty"
                         )
                         continue
-
-                    parsed_outputs = self._parse(response)
+                    parsed_outputs = self._handle_message(message)
+                    # parsed_outputs = self._parse(response)
 
                     if not parsed_outputs or not any(
                         len(value) > 0 for value in parsed_outputs.values()
                     ):
                         logger.warning(
-                            f"Failed to parse content from list item {i}. Raw output length: {len(response)}, "
+                            f"Failed to parse content from list item {i}. Raw output length: {len(message)}, "
                             f"parsing method: {'regex' if self.parsing_pattern else 'tags'}"
                         )
                         continue
@@ -283,21 +298,21 @@ class TextParserBlock(BaseBlock):
             else:
                 # When expand_lists=True, use existing expanding behavior
                 all_results = []
-                for i, response in enumerate(raw_output):
-                    if not response or not isinstance(response, str):
+                for i, message in enumerate(raw_output):
+                    if not message:
                         logger.warning(
-                            f"List item {i} in column '{input_column}' contains invalid data "
-                            f"(empty or non-string): {type(response)}"
+                            f"List item {i} in column '{input_column}' is empty"
                         )
                         continue
 
-                    parsed_outputs = self._parse(response)
+                    # parsed_outputs = self._parse(message)
+                    parsed_outputs = self._handle_message(message)
 
                     if not parsed_outputs or not any(
                         len(value) > 0 for value in parsed_outputs.values()
                     ):
                         logger.warning(
-                            f"Failed to parse content from list item {i}. Raw output length: {len(response)}, "
+                            f"Failed to parse content from list item {i}. Raw output length: {len(message)}, "
                             f"parsing method: {'regex' if self.parsing_pattern else 'tags'}"
                         )
                         continue
@@ -314,12 +329,12 @@ class TextParserBlock(BaseBlock):
                 return all_results
 
         # Handle string inputs (existing logic)
-        elif isinstance(raw_output, str):
+        elif isinstance(raw_output, dict):
             if not raw_output:
                 logger.warning(f"Input column '{input_column}' contains empty string")
                 return []
 
-            parsed_outputs = self._parse(raw_output)
+            parsed_outputs = self._handle_message(raw_output)
 
             if not parsed_outputs or not any(
                 len(value) > 0 for value in parsed_outputs.values()

--- a/src/sdg_hub/core/blocks/llm/text_parser_block.py
+++ b/src/sdg_hub/core/blocks/llm/text_parser_block.py
@@ -247,6 +247,9 @@ class TextParserBlock(BaseBlock):
         return value
 
     def _handle_message(self, sample: dict) -> dict[str, list[str]]:
+        if "content" not in sample:
+            logger.warning(f"Content not found in sample: {sample}")
+            return {}
         parsed_output = self._parse(sample["content"])
         if self.save_reasoning_content:
             parsed_output[self.reasoning_content_field] = self._get_reasoning_content(
@@ -400,7 +403,7 @@ class TextParserBlock(BaseBlock):
         else:
             logger.warning(
                 f"Input column '{input_column}' contains invalid data type: {type(raw_output)}. "
-                f"Expected str or List[str]"
+                f"Expected dict or List[dict]"
             )
             return []
 

--- a/src/sdg_hub/core/blocks/llm/text_parser_block.py
+++ b/src/sdg_hub/core/blocks/llm/text_parser_block.py
@@ -78,7 +78,7 @@ class TextParserBlock(BaseBlock):
         description="Whether to save the reasoning content to the output.",
     )
     reasoning_content_field: Optional[str] = Field(
-        default="reasoning_content",
+        default='reasoning_content',
         description="The field name of the reasoning content to save to the output.",
     )
 
@@ -246,35 +246,33 @@ class TextParserBlock(BaseBlock):
                 value = value.replace(clean_tag, "")
         return value
 
+    
     def _handle_message(self, sample: dict) -> dict[str, list[str]]:
-        parsed_output = self._parse(sample["content"])
-
+        parsed_output = self._parse(sample['content'])
         if self.save_reasoning_content:
-            parsed_output[self.reasoning_content_field] = self._get_reasoning_content(
-                sample
-            )
+            parsed_output[self.reasoning_content_field] = self._get_reasoning_content(sample)
         return parsed_output
-
+    
     def _get_reasoning_content(self, sample: dict) -> str:
         if self.save_reasoning_content:
             if self.reasoning_content_field in sample:
                 return sample[self.reasoning_content_field]
             else:
-                logger.warning(
-                    f"Reasoning content field '{self.reasoning_content_field}' not found in response"
-                )
+                logger.warning(f"Reasoning content field '{self.reasoning_content_field}' not found in response")
                 return ""
-
+            
+        
     def _generate(self, sample: dict) -> list[dict]:
         input_column = self.input_cols[0]
         raw_output = sample[input_column]
+        
 
         # Handle list inputs (e.g., from LLMChatBlock with n > 1)
         if isinstance(raw_output, list):
             if not raw_output:
                 logger.warning(f"Input column '{input_column}' contains empty list")
                 return []
-
+            
             if not self.expand_lists:
                 # When expand_lists=False, preserve the list structure
                 # Parse each response in the list and collect results as lists
@@ -287,12 +285,10 @@ class TextParserBlock(BaseBlock):
                             f"List item {i} in column '{input_column}' is empty"
                         )
                         continue
-
+                    
                     parsed_outputs = self._handle_message(message)
                     if self.save_reasoning_content:
-                        reasoning_content = parsed_outputs.pop(
-                            self.reasoning_content_field
-                        )
+                        reasoning_content = parsed_outputs.pop(self.reasoning_content_field)
 
                     if not parsed_outputs or not any(
                         len(value) > 0 for value in parsed_outputs.values()
@@ -308,9 +304,9 @@ class TextParserBlock(BaseBlock):
                     for col in self.output_cols:
                         all_parsed_outputs[col].extend(parsed_outputs.get(col, []))
                     if self.save_reasoning_content:
-                        all_parsed_outputs[
-                            self.block_name + "_" + self.reasoning_content_field
-                        ].append(reasoning_content)
+                        if self.block_name + '_' + self.reasoning_content_field not in all_parsed_outputs:
+                            all_parsed_outputs[self.block_name + '_' + self.reasoning_content_field] = []
+                        all_parsed_outputs[self.block_name + '_' + self.reasoning_content_field].append(reasoning_content)
 
                 if valid_responses == 0:
                     return []
@@ -330,9 +326,7 @@ class TextParserBlock(BaseBlock):
 
                     parsed_outputs = self._handle_message(message)
                     if self.save_reasoning_content:
-                        reasoning_content = parsed_outputs.pop(
-                            self.reasoning_content_field
-                        )
+                        reasoning_content = parsed_outputs.pop(self.reasoning_content_field)
 
                     if not parsed_outputs or not any(
                         len(value) > 0 for value in parsed_outputs.values()
@@ -348,27 +342,24 @@ class TextParserBlock(BaseBlock):
                     for values in zip(
                         *(lst[:max_length] for lst in parsed_outputs.values())
                     ):
-                        result_row = {
-                            **sample,
-                            **dict(zip(parsed_outputs.keys(), values)),
-                        }
+                        result_row = {**sample, **dict(zip(parsed_outputs.keys(), values))}
                         if self.save_reasoning_content:
-                            result_row[
-                                self.block_name + "_" + self.reasoning_content_field
-                            ] = reasoning_content
+                            result_row[self.block_name + '_' + self.reasoning_content_field] = reasoning_content
                         all_results.append(result_row)
+                        
 
                 return all_results
 
-        # Handle string inputs (existing logic)
+        # Handle dict inputs (existing logic)
         elif isinstance(raw_output, dict):
             if not raw_output:
-                logger.warning(f"Input column '{input_column}' contains empty string")
+                logger.warning(f"Input column '{input_column}' contains empty dict")
                 return []
-
+            
             parsed_outputs = self._handle_message(raw_output)
             if self.save_reasoning_content:
                 reasoning_content = parsed_outputs.pop(self.reasoning_content_field)
+
 
             if not parsed_outputs or not any(
                 len(value) > 0 for value in parsed_outputs.values()
@@ -384,11 +375,10 @@ class TextParserBlock(BaseBlock):
             for values in zip(*(lst[:max_length] for lst in parsed_outputs.values())):
                 result_row = {**sample, **dict(zip(parsed_outputs.keys(), values))}
                 if self.save_reasoning_content:
-                    result_row[self.block_name + "_" + self.reasoning_content_field] = (
-                        reasoning_content
-                    )
+                    result_row[self.block_name + '_' + self.reasoning_content_field] = reasoning_content
                 result.append(result_row)
-
+                
+                
             return result
 
         else:

--- a/tests/blocks/llm/test_textparserblock.py
+++ b/tests/blocks/llm/test_textparserblock.py
@@ -1031,7 +1031,7 @@ def test_generate_with_invalid_input_type():
     )
 
     # Test with list of strings (invalid type - should be list of dicts)
-    data = [{"raw_output": ['test']}]  # list of strings instead of list of dicts
+    data = [{"raw_output": ["test"]}]  # list of strings instead of list of dicts
     dataset = Dataset.from_list(data)
 
     with patch("sdg_hub.core.blocks.llm.text_parser_block.logger") as mock_logger:
@@ -1041,7 +1041,9 @@ def test_generate_with_invalid_input_type():
         mock_logger.warning.assert_called()
         warning_calls = [call[0][0] for call in mock_logger.warning.call_args_list]
         assert any("Content not found in sample" in call for call in warning_calls)
-        assert any("Failed to parse content from list item" in call for call in warning_calls)
+        assert any(
+            "Failed to parse content from list item" in call for call in warning_calls
+        )
 
         # Should return empty result
         assert len(result) == 0

--- a/tests/blocks/llm/test_textparserblock.py
+++ b/tests/blocks/llm/test_textparserblock.py
@@ -1286,3 +1286,508 @@ def test_expand_lists_default_value():
     assert len(result) == 2
     assert result[0]["entity"] == "A"
     assert result[1]["entity"] == "B"
+
+
+# Tests for save_reasoning_content functionality
+def test_save_reasoning_content_basic_dict_input():
+    """Test basic save_reasoning_content functionality with dict input."""
+    block = TextParserBlock(
+        block_name="test_block",
+        input_cols="raw_output",
+        output_cols=["output"],
+        start_tags=["<answer>"],
+        end_tags=["</answer>"],
+        save_reasoning_content=True,
+    )
+
+    data = [
+        {
+            "raw_output": {
+                "content": "<answer>Final answer</answer>",
+                "reasoning_content": "This is my reasoning process"
+            }
+        }
+    ]
+    dataset = Dataset.from_list(data)
+
+    result = block.generate(dataset)
+
+    assert len(result) == 1
+    assert result[0]["output"] == "Final answer"
+    assert result[0]["test_block_reasoning_content"] == "This is my reasoning process"
+
+
+def test_save_reasoning_content_custom_field_name():
+    """Test save_reasoning_content with custom field name."""
+    block = TextParserBlock(
+        block_name="parser",
+        input_cols="raw_output",
+        output_cols=["answer"],
+        start_tags=["<answer>"],
+        end_tags=["</answer>"],
+        save_reasoning_content=True,
+        reasoning_content_field="custom_reasoning",
+    )
+
+    data = [
+        {
+            "raw_output": {
+                "content": "<answer>My answer</answer>",
+                "custom_reasoning": "Custom reasoning field content"
+            }
+        }
+    ]
+    dataset = Dataset.from_list(data)
+
+    result = block.generate(dataset)
+
+    assert len(result) == 1
+    assert result[0]["answer"] == "My answer"
+    assert result[0]["parser_custom_reasoning"] == "Custom reasoning field content"
+
+
+def test_save_reasoning_content_disabled_by_default():
+    """Test that save_reasoning_content is disabled by default."""
+    block = TextParserBlock(
+        block_name="test_block",
+        input_cols="raw_output",
+        output_cols=["output"],
+        start_tags=["<answer>"],
+        end_tags=["</answer>"],
+        # save_reasoning_content not specified - should default to False
+    )
+
+    # Verify default value
+    assert block.save_reasoning_content is False
+
+    data = [
+        {
+            "raw_output": {
+                "content": "<answer>Final answer</answer>",
+                "reasoning_content": "This reasoning should not be saved"
+            }
+        }
+    ]
+    dataset = Dataset.from_list(data)
+
+    result = block.generate(dataset)
+
+    assert len(result) == 1
+    assert result[0]["output"] == "Final answer"
+    # Should not have reasoning content field
+    assert "test_block_reasoning_content" not in result[0]
+
+
+def test_save_reasoning_content_missing_field():
+    """Test save_reasoning_content when reasoning field is missing from input."""
+    block = TextParserBlock(
+        block_name="test_block",
+        input_cols="raw_output",
+        output_cols=["output"],
+        start_tags=["<answer>"],
+        end_tags=["</answer>"],
+        save_reasoning_content=True,
+    )
+
+    data = [
+        {
+            "raw_output": {
+                "content": "<answer>Final answer</answer>",
+                # No reasoning_content field
+            }
+        }
+    ]
+    dataset = Dataset.from_list(data)
+
+    with patch("sdg_hub.core.blocks.llm.text_parser_block.logger") as mock_logger:
+        result = block.generate(dataset)
+
+        # Should log warning about missing field
+        mock_logger.warning.assert_called()
+        warning_calls = [call[0][0] for call in mock_logger.warning.call_args_list]
+        assert any("Reasoning content field 'reasoning_content' not found" in call for call in warning_calls)
+
+        assert len(result) == 1
+        assert result[0]["output"] == "Final answer"
+        assert result[0]["test_block_reasoning_content"] == ""
+
+
+def test_save_reasoning_content_with_regex_parsing():
+    """Test save_reasoning_content with regex parsing."""
+    block = TextParserBlock(
+        block_name="regex_block",
+        input_cols="raw_output",
+        output_cols=["answer"],
+        parsing_pattern=r"Answer: (.*?)(?:\n|$)",
+        save_reasoning_content=True,
+    )
+
+    data = [
+        {
+            "raw_output": {
+                "content": "Question: What is 2+2?\nAnswer: Four",
+                "reasoning_content": "Simple arithmetic calculation"
+            }
+        }
+    ]
+    dataset = Dataset.from_list(data)
+
+    result = block.generate(dataset)
+
+    assert len(result) == 1
+    assert result[0]["answer"] == "Four"
+    assert result[0]["regex_block_reasoning_content"] == "Simple arithmetic calculation"
+
+
+def test_save_reasoning_content_list_input_expand_true():
+    """Test save_reasoning_content with list input and expand_lists=True."""
+    block = TextParserBlock(
+        block_name="test_block",
+        input_cols="raw_output",
+        output_cols=["output"],
+        start_tags=["<answer>"],
+        end_tags=["</answer>"],
+        save_reasoning_content=True,
+        expand_lists=True,
+    )
+
+    data = [
+        {
+            "raw_output": [
+                {
+                    "content": "<answer>First answer</answer>",
+                    "reasoning_content": "First reasoning"
+                },
+                {
+                    "content": "<answer>Second answer</answer>",
+                    "reasoning_content": "Second reasoning"
+                },
+            ]
+        }
+    ]
+    dataset = Dataset.from_list(data)
+
+    result = block.generate(dataset)
+
+    # Should create separate rows for each response
+    assert len(result) == 2
+    assert result[0]["output"] == "First answer"
+    assert result[0]["test_block_reasoning_content"] == "First reasoning"
+    assert result[1]["output"] == "Second answer"
+    assert result[1]["test_block_reasoning_content"] == "Second reasoning"
+
+
+def test_save_reasoning_content_list_input_expand_false():
+    """Test save_reasoning_content with list input and expand_lists=False."""
+    block = TextParserBlock(
+        block_name="test_block",
+        input_cols="raw_output",
+        output_cols=["output"],
+        start_tags=["<answer>"],
+        end_tags=["</answer>"],
+        save_reasoning_content=True,
+        expand_lists=False,
+    )
+
+    data = [
+        {
+            "raw_output": [
+                {
+                    "content": "<answer>First answer</answer>",
+                    "reasoning_content": "First reasoning"
+                },
+                {
+                    "content": "<answer>Second answer</answer>",
+                    "reasoning_content": "Second reasoning"
+                },
+            ]
+        }
+    ]
+    dataset = Dataset.from_list(data)
+
+    result = block.generate(dataset)
+    print(result)
+    # Should create single row with lists
+    assert len(result) == 1
+    assert result[0]["output"] == ["First answer", "Second answer"]
+    assert result[0]["test_block_reasoning_content"] == ["First reasoning", "Second reasoning"]
+
+
+def test_save_reasoning_content_list_input_multiple_matches():
+    """Test save_reasoning_content with list input where each response has multiple matches."""
+    block = TextParserBlock(
+        block_name="test_block",
+        input_cols="raw_output",
+        output_cols=["title", "content"],
+        start_tags=["<title>", "<content>"],
+        end_tags=["</title>", "</content>"],
+        save_reasoning_content=True,
+        expand_lists=True,
+    )
+
+    data = [
+        {
+            "raw_output": [
+                {
+                    "content": "<title>Title 1</title><content>Content 1</content><title>Title 2</title><content>Content 2</content>",
+                    "reasoning_content": "First response reasoning"
+                },
+                {
+                    "content": "<title>Title 3</title><content>Content 3</content>",
+                    "reasoning_content": "Second response reasoning"
+                },
+            ]
+        }
+    ]
+    dataset = Dataset.from_list(data)
+
+    result = block.generate(dataset)
+
+    # Should create 3 rows total (2 from first response, 1 from second)
+    assert len(result) == 3
+    assert result[0]["title"] == "Title 1"
+    assert result[0]["content"] == "Content 1"
+    assert result[0]["test_block_reasoning_content"] == "First response reasoning"
+    assert result[1]["title"] == "Title 2"
+    assert result[1]["content"] == "Content 2"
+    assert result[1]["test_block_reasoning_content"] == "First response reasoning"
+    assert result[2]["title"] == "Title 3"
+    assert result[2]["content"] == "Content 3"
+    assert result[2]["test_block_reasoning_content"] == "Second response reasoning"
+
+
+def test_save_reasoning_content_list_input_expand_false_multiple_matches():
+    """Test save_reasoning_content with list input, expand_lists=False, and multiple matches per response."""
+    block = TextParserBlock(
+        block_name="test_block",
+        input_cols="raw_output",
+        output_cols=["entity"],
+        start_tags=["<entity>"],
+        end_tags=["</entity>"],
+        save_reasoning_content=True,
+        expand_lists=False,
+    )
+
+    data = [
+        {
+            "raw_output": [
+                {
+                    "content": "<entity>A</entity><entity>B</entity>",
+                    "reasoning_content": "First reasoning"
+                },
+                {
+                    "content": "<entity>C</entity>",
+                    "reasoning_content": "Second reasoning"
+                },
+            ]
+        }
+    ]
+    dataset = Dataset.from_list(data)
+
+    result = block.generate(dataset)
+
+    # Should create single row with lists
+    assert len(result) == 1
+    assert result[0]["entity"] == ["A", "B", "C"]
+    assert result[0]["test_block_reasoning_content"] == ["First reasoning", "Second reasoning"]
+
+
+def test_save_reasoning_content_list_input_mixed_valid_invalid():
+    """Test save_reasoning_content with list input containing valid and invalid responses."""
+    block = TextParserBlock(
+        block_name="test_block",
+        input_cols="raw_output",
+        output_cols=["output"],
+        start_tags=["<answer>"],
+        end_tags=["</answer>"],
+        save_reasoning_content=True,
+        expand_lists=True,
+    )
+
+    data = [
+        {
+            "raw_output": [
+                {
+                    "content": "<answer>Valid answer 1</answer>",
+                    "reasoning_content": "Valid reasoning 1"
+                },
+                {
+                    "content": "No tags here",  # Will fail to parse
+                    "reasoning_content": "This reasoning won't be used"
+                },
+                {
+                    "content": "<answer>Valid answer 2</answer>",
+                    "reasoning_content": "Valid reasoning 2"
+                },
+            ]
+        }
+    ]
+    dataset = Dataset.from_list(data)
+
+    with patch("sdg_hub.core.blocks.llm.text_parser_block.logger") as mock_logger:
+        result = block.generate(dataset)
+
+        # Should process only the 2 valid responses
+        assert len(result) == 2
+        assert result[0]["output"] == "Valid answer 1"
+        assert result[0]["test_block_reasoning_content"] == "Valid reasoning 1"
+        assert result[1]["output"] == "Valid answer 2"
+        assert result[1]["test_block_reasoning_content"] == "Valid reasoning 2"
+
+        # Should log warning for parsing failure
+        warning_calls = [call[0][0] for call in mock_logger.warning.call_args_list]
+        assert any("Failed to parse content from list item 1" in call for call in warning_calls)
+
+
+def test_save_reasoning_content_empty_reasoning_field():
+    """Test save_reasoning_content when reasoning field is empty."""
+    block = TextParserBlock(
+        block_name="test_block",
+        input_cols="raw_output",
+        output_cols=["output"],
+        start_tags=["<answer>"],
+        end_tags=["</answer>"],
+        save_reasoning_content=True,
+    )
+
+    data = [
+        {
+            "raw_output": {
+                "content": "<answer>Final answer</answer>",
+                "reasoning_content": ""  # Empty reasoning content
+            }
+        }
+    ]
+    dataset = Dataset.from_list(data)
+
+    result = block.generate(dataset)
+
+    assert len(result) == 1
+    assert result[0]["output"] == "Final answer"
+    assert result[0]["test_block_reasoning_content"] == ""
+
+
+def test_save_reasoning_content_default_field_name():
+    """Test that reasoning_content_field defaults to 'reasoning_content'."""
+    block = TextParserBlock(
+        block_name="test_block",
+        input_cols="raw_output",
+        output_cols=["output"],
+        start_tags=["<answer>"],
+        end_tags=["</answer>"],
+        save_reasoning_content=True,
+        # reasoning_content_field not specified - should default to 'reasoning_content'
+    )
+
+    # Verify default value
+    assert block.reasoning_content_field == "reasoning_content"
+
+    data = [
+        {
+            "raw_output": {
+                "content": "<answer>Final answer</answer>",
+                "reasoning_content": "Default field reasoning"
+            }
+        }
+    ]
+    dataset = Dataset.from_list(data)
+
+    result = block.generate(dataset)
+
+    assert len(result) == 1
+    assert result[0]["output"] == "Final answer"
+    assert result[0]["test_block_reasoning_content"] == "Default field reasoning"
+
+
+def test_save_reasoning_content_multiple_responses_one_per_row():
+    """Test that when n>1, each row gets its corresponding reasoning content."""
+    block = TextParserBlock(
+        block_name="test_block",
+        input_cols="raw_output",
+        output_cols=["output"],
+        start_tags=["<answer>"],
+        end_tags=["</answer>"],
+        save_reasoning_content=True,
+        expand_lists=True,
+    )
+
+    # Simulate LLMChatBlock output with n=3 (3 different responses)
+    data = [
+        {
+            "raw_output": [
+                {
+                    "content": "<answer>Response 1</answer>",
+                    "reasoning_content": "Reasoning for response 1"
+                },
+                {
+                    "content": "<answer>Response 2</answer>",
+                    "reasoning_content": "Reasoning for response 2"
+                },
+                {
+                    "content": "<answer>Response 3</answer>",
+                    "reasoning_content": "Reasoning for response 3"
+                },
+            ]
+        }
+    ]
+    dataset = Dataset.from_list(data)
+
+    result = block.generate(dataset)
+
+    # Should create 3 separate rows, each with its own reasoning
+    assert len(result) == 3
+    
+    # Each row should have the reasoning content from its corresponding response
+    assert result[0]["output"] == "Response 1"
+    assert result[0]["test_block_reasoning_content"] == "Reasoning for response 1"
+    
+    assert result[1]["output"] == "Response 2"
+    assert result[1]["test_block_reasoning_content"] == "Reasoning for response 2"
+    
+    assert result[2]["output"] == "Response 3"
+    assert result[2]["test_block_reasoning_content"] == "Reasoning for response 3"
+
+
+def test_save_reasoning_content_multiple_responses_collected_as_list():
+    """Test that when n>1 and expand_lists=False, reasoning contents are collected as a list."""
+    block = TextParserBlock(
+        block_name="test_block",
+        input_cols="raw_output",
+        output_cols=["output"],
+        start_tags=["<answer>"],
+        end_tags=["</answer>"],
+        save_reasoning_content=True,
+        expand_lists=False,
+    )
+
+    # Simulate LLMChatBlock output with n=3 (3 different responses)
+    data = [
+        {
+            "raw_output": [
+                {
+                    "content": "<answer>Response 1</answer>",
+                    "reasoning_content": "Reasoning for response 1"
+                },
+                {
+                    "content": "<answer>Response 2</answer>",
+                    "reasoning_content": "Reasoning for response 2"
+                },
+                {
+                    "content": "<answer>Response 3</answer>",
+                    "reasoning_content": "Reasoning for response 3"
+                },
+            ]
+        }
+    ]
+    dataset = Dataset.from_list(data)
+
+    result = block.generate(dataset)
+
+    # Should create single row with lists containing all responses and reasoning
+    assert len(result) == 1
+    assert result[0]["output"] == ["Response 1", "Response 2", "Response 3"]
+    # assert result[0]["test_block_reasoning_content"] == [
+    #     "Reasoning for response 1", 
+    #     "Reasoning for response 2", 
+    #     "Reasoning for response 3"
+    # ]

--- a/tests/blocks/llm/test_textparserblock.py
+++ b/tests/blocks/llm/test_textparserblock.py
@@ -1304,7 +1304,7 @@ def test_save_reasoning_content_basic_dict_input():
         {
             "raw_output": {
                 "content": "<answer>Final answer</answer>",
-                "reasoning_content": "This is my reasoning process"
+                "reasoning_content": "This is my reasoning process",
             }
         }
     ]
@@ -1333,7 +1333,7 @@ def test_save_reasoning_content_custom_field_name():
         {
             "raw_output": {
                 "content": "<answer>My answer</answer>",
-                "custom_reasoning": "Custom reasoning field content"
+                "custom_reasoning": "Custom reasoning field content",
             }
         }
     ]
@@ -1364,7 +1364,7 @@ def test_save_reasoning_content_disabled_by_default():
         {
             "raw_output": {
                 "content": "<answer>Final answer</answer>",
-                "reasoning_content": "This reasoning should not be saved"
+                "reasoning_content": "This reasoning should not be saved",
             }
         }
     ]
@@ -1405,7 +1405,10 @@ def test_save_reasoning_content_missing_field():
         # Should log warning about missing field
         mock_logger.warning.assert_called()
         warning_calls = [call[0][0] for call in mock_logger.warning.call_args_list]
-        assert any("Reasoning content field 'reasoning_content' not found" in call for call in warning_calls)
+        assert any(
+            "Reasoning content field 'reasoning_content' not found" in call
+            for call in warning_calls
+        )
 
         assert len(result) == 1
         assert result[0]["output"] == "Final answer"
@@ -1426,7 +1429,7 @@ def test_save_reasoning_content_with_regex_parsing():
         {
             "raw_output": {
                 "content": "Question: What is 2+2?\nAnswer: Four",
-                "reasoning_content": "Simple arithmetic calculation"
+                "reasoning_content": "Simple arithmetic calculation",
             }
         }
     ]
@@ -1456,11 +1459,11 @@ def test_save_reasoning_content_list_input_expand_true():
             "raw_output": [
                 {
                     "content": "<answer>First answer</answer>",
-                    "reasoning_content": "First reasoning"
+                    "reasoning_content": "First reasoning",
                 },
                 {
                     "content": "<answer>Second answer</answer>",
-                    "reasoning_content": "Second reasoning"
+                    "reasoning_content": "Second reasoning",
                 },
             ]
         }
@@ -1494,11 +1497,11 @@ def test_save_reasoning_content_list_input_expand_false():
             "raw_output": [
                 {
                     "content": "<answer>First answer</answer>",
-                    "reasoning_content": "First reasoning"
+                    "reasoning_content": "First reasoning",
                 },
                 {
                     "content": "<answer>Second answer</answer>",
-                    "reasoning_content": "Second reasoning"
+                    "reasoning_content": "Second reasoning",
                 },
             ]
         }
@@ -1510,7 +1513,10 @@ def test_save_reasoning_content_list_input_expand_false():
     # Should create single row with lists
     assert len(result) == 1
     assert result[0]["output"] == ["First answer", "Second answer"]
-    assert result[0]["test_block_reasoning_content"] == ["First reasoning", "Second reasoning"]
+    assert result[0]["test_block_reasoning_content"] == [
+        "First reasoning",
+        "Second reasoning",
+    ]
 
 
 def test_save_reasoning_content_list_input_multiple_matches():
@@ -1530,11 +1536,11 @@ def test_save_reasoning_content_list_input_multiple_matches():
             "raw_output": [
                 {
                     "content": "<title>Title 1</title><content>Content 1</content><title>Title 2</title><content>Content 2</content>",
-                    "reasoning_content": "First response reasoning"
+                    "reasoning_content": "First response reasoning",
                 },
                 {
                     "content": "<title>Title 3</title><content>Content 3</content>",
-                    "reasoning_content": "Second response reasoning"
+                    "reasoning_content": "Second response reasoning",
                 },
             ]
         }
@@ -1573,11 +1579,11 @@ def test_save_reasoning_content_list_input_expand_false_multiple_matches():
             "raw_output": [
                 {
                     "content": "<entity>A</entity><entity>B</entity>",
-                    "reasoning_content": "First reasoning"
+                    "reasoning_content": "First reasoning",
                 },
                 {
                     "content": "<entity>C</entity>",
-                    "reasoning_content": "Second reasoning"
+                    "reasoning_content": "Second reasoning",
                 },
             ]
         }
@@ -1589,7 +1595,10 @@ def test_save_reasoning_content_list_input_expand_false_multiple_matches():
     # Should create single row with lists
     assert len(result) == 1
     assert result[0]["entity"] == ["A", "B", "C"]
-    assert result[0]["test_block_reasoning_content"] == ["First reasoning", "Second reasoning"]
+    assert result[0]["test_block_reasoning_content"] == [
+        "First reasoning",
+        "Second reasoning",
+    ]
 
 
 def test_save_reasoning_content_list_input_mixed_valid_invalid():
@@ -1609,15 +1618,15 @@ def test_save_reasoning_content_list_input_mixed_valid_invalid():
             "raw_output": [
                 {
                     "content": "<answer>Valid answer 1</answer>",
-                    "reasoning_content": "Valid reasoning 1"
+                    "reasoning_content": "Valid reasoning 1",
                 },
                 {
                     "content": "No tags here",  # Will fail to parse
-                    "reasoning_content": "This reasoning won't be used"
+                    "reasoning_content": "This reasoning won't be used",
                 },
                 {
                     "content": "<answer>Valid answer 2</answer>",
-                    "reasoning_content": "Valid reasoning 2"
+                    "reasoning_content": "Valid reasoning 2",
                 },
             ]
         }
@@ -1636,7 +1645,9 @@ def test_save_reasoning_content_list_input_mixed_valid_invalid():
 
         # Should log warning for parsing failure
         warning_calls = [call[0][0] for call in mock_logger.warning.call_args_list]
-        assert any("Failed to parse content from list item 1" in call for call in warning_calls)
+        assert any(
+            "Failed to parse content from list item 1" in call for call in warning_calls
+        )
 
 
 def test_save_reasoning_content_empty_reasoning_field():
@@ -1654,7 +1665,7 @@ def test_save_reasoning_content_empty_reasoning_field():
         {
             "raw_output": {
                 "content": "<answer>Final answer</answer>",
-                "reasoning_content": ""  # Empty reasoning content
+                "reasoning_content": "",  # Empty reasoning content
             }
         }
     ]
@@ -1686,7 +1697,7 @@ def test_save_reasoning_content_default_field_name():
         {
             "raw_output": {
                 "content": "<answer>Final answer</answer>",
-                "reasoning_content": "Default field reasoning"
+                "reasoning_content": "Default field reasoning",
             }
         }
     ]
@@ -1717,15 +1728,15 @@ def test_save_reasoning_content_multiple_responses_one_per_row():
             "raw_output": [
                 {
                     "content": "<answer>Response 1</answer>",
-                    "reasoning_content": "Reasoning for response 1"
+                    "reasoning_content": "Reasoning for response 1",
                 },
                 {
                     "content": "<answer>Response 2</answer>",
-                    "reasoning_content": "Reasoning for response 2"
+                    "reasoning_content": "Reasoning for response 2",
                 },
                 {
                     "content": "<answer>Response 3</answer>",
-                    "reasoning_content": "Reasoning for response 3"
+                    "reasoning_content": "Reasoning for response 3",
                 },
             ]
         }
@@ -1736,14 +1747,14 @@ def test_save_reasoning_content_multiple_responses_one_per_row():
 
     # Should create 3 separate rows, each with its own reasoning
     assert len(result) == 3
-    
+
     # Each row should have the reasoning content from its corresponding response
     assert result[0]["output"] == "Response 1"
     assert result[0]["test_block_reasoning_content"] == "Reasoning for response 1"
-    
+
     assert result[1]["output"] == "Response 2"
     assert result[1]["test_block_reasoning_content"] == "Reasoning for response 2"
-    
+
     assert result[2]["output"] == "Response 3"
     assert result[2]["test_block_reasoning_content"] == "Reasoning for response 3"
 
@@ -1766,15 +1777,15 @@ def test_save_reasoning_content_multiple_responses_collected_as_list():
             "raw_output": [
                 {
                     "content": "<answer>Response 1</answer>",
-                    "reasoning_content": "Reasoning for response 1"
+                    "reasoning_content": "Reasoning for response 1",
                 },
                 {
                     "content": "<answer>Response 2</answer>",
-                    "reasoning_content": "Reasoning for response 2"
+                    "reasoning_content": "Reasoning for response 2",
                 },
                 {
                     "content": "<answer>Response 3</answer>",
-                    "reasoning_content": "Reasoning for response 3"
+                    "reasoning_content": "Reasoning for response 3",
                 },
             ]
         }
@@ -1787,7 +1798,7 @@ def test_save_reasoning_content_multiple_responses_collected_as_list():
     assert len(result) == 1
     assert result[0]["output"] == ["Response 1", "Response 2", "Response 3"]
     assert result[0]["test_block_reasoning_content"] == [
-        "Reasoning for response 1", 
-        "Reasoning for response 2", 
-        "Reasoning for response 3"
+        "Reasoning for response 1",
+        "Reasoning for response 2",
+        "Reasoning for response 3",
     ]

--- a/tests/blocks/llm/test_textparserblock.py
+++ b/tests/blocks/llm/test_textparserblock.py
@@ -1030,18 +1030,18 @@ def test_generate_with_invalid_input_type():
         end_tags=["</answer>"],
     )
 
-    # Test with integer input (invalid type)
-    data = [{"raw_output": 123}]  # Integer instead of dict or list
+    # Test with list of strings (invalid type - should be list of dicts)
+    data = [{"raw_output": ['test']}]  # list of strings instead of list of dicts
     dataset = Dataset.from_list(data)
 
     with patch("sdg_hub.core.blocks.llm.text_parser_block.logger") as mock_logger:
         result = block.generate(dataset)
 
-        # Should log warning about invalid data type
+        # Should log warnings about content not found and parsing failure
         mock_logger.warning.assert_called()
         warning_calls = [call[0][0] for call in mock_logger.warning.call_args_list]
-        assert any("invalid data type" in call for call in warning_calls)
-        assert any("Expected str or List[str]" in call for call in warning_calls)
+        assert any("Content not found in sample" in call for call in warning_calls)
+        assert any("Failed to parse content from list item" in call for call in warning_calls)
 
         # Should return empty result
         assert len(result) == 0
@@ -1509,7 +1509,6 @@ def test_save_reasoning_content_list_input_expand_false():
     dataset = Dataset.from_list(data)
 
     result = block.generate(dataset)
-    print(result)
     # Should create single row with lists
     assert len(result) == 1
     assert result[0]["output"] == ["First answer", "Second answer"]

--- a/tests/blocks/llm/test_textparserblock.py
+++ b/tests/blocks/llm/test_textparserblock.py
@@ -160,8 +160,8 @@ def test_generate_basic_functionality(postprocessing_block):
     postprocessing_block.end_tags = ["</output>"]
 
     data = [
-        {"raw_output": "Text <output>Result 1</output> more text"},
-        {"raw_output": "Text <output>Result 2</output> more text"},
+        {"raw_output": {"content": "Text <output>Result 1</output> more text"}},
+        {"raw_output": {"content": "Text <output>Result 2</output> more text"}},
     ]
     dataset = Dataset.from_list(data)
 
@@ -175,8 +175,8 @@ def test_generate_basic_functionality(postprocessing_block):
 def test_generate_custom_regex(postprocessing_block_with_custom_parser):
     """Test generate functionality with custom regex parsing."""
     data = [
-        {"raw_output": "Question: Q1\nAnswer: A1"},
-        {"raw_output": "Question: Q2\nAnswer: A2"},
+        {"raw_output": {"content": "Question: Q1\nAnswer: A1"}},
+        {"raw_output": {"content": "Question: Q2\nAnswer: A2"}},
     ]
     dataset = Dataset.from_list(data)
 
@@ -191,12 +191,14 @@ def test_generate_multiple_matches_per_input(postprocessing_block_multi_column):
     """Test generate functionality with multiple matches per input."""
     data = [
         {
-            "raw_output": """
+            "raw_output": {
+                "content": """
             <title>Title 1</title>
             <content>Content 1</content>
             <title>Title 2</title>
             <content>Content 2</content>
             """
+            }
         }
     ]
     dataset = Dataset.from_list(data)
@@ -238,8 +240,8 @@ def test_generate_all_empty_parsed_outputs(postprocessing_block):
     postprocessing_block.end_tags = ["</output>"]
 
     data = [
-        {"raw_output": "Text without any tags"},
-        {"raw_output": "More text without tags"},
+        {"raw_output": {"content": "Text without any tags"}},
+        {"raw_output": {"content": "More text without tags"}},
     ]
     dataset = Dataset.from_list(data)
 
@@ -254,8 +256,12 @@ def test_generate_all_empty_parsed_outputs_custom_parser(
 ):
     """Test generate functionality with custom parser when all parsed outputs are empty."""
     data = [
-        {"raw_output": "Question: What is the answer?\nNo answer provided"},
-        {"raw_output": "Another question without answer"},
+        {
+            "raw_output": {
+                "content": "Question: What is the answer?\nNo answer provided"
+            }
+        },
+        {"raw_output": {"content": "Another question without answer"}},
     ]
     dataset = Dataset.from_list(data)
 
@@ -618,7 +624,7 @@ def test_validation_regex_only_configuration():
         # No tags specified - this should be valid
     )
 
-    data = [{"raw_output": "Answer: test response"}]
+    data = [{"raw_output": {"content": "Answer: test response"}}]
     dataset = Dataset.from_list(data)
 
     # Should not raise validation errors
@@ -638,7 +644,7 @@ def test_validation_tags_only_configuration():
         # No parsing_pattern - this should be valid
     )
 
-    data = [{"raw_output": "<answer>test response</answer>"}]
+    data = [{"raw_output": {"content": "<answer>test response</answer>"}}]
     dataset = Dataset.from_list(data)
 
     # Should not raise validation errors
@@ -689,7 +695,7 @@ def test_enhanced_logging_for_parsing_failures():
     )
 
     # Test with input that won't match the pattern
-    data = [{"raw_output": "No tags in this text"}]
+    data = [{"raw_output": {"content": "No tags in this text"}}]
     dataset = Dataset.from_list(data)
 
     with patch("sdg_hub.core.blocks.llm.text_parser_block.logger") as mock_logger:
@@ -733,17 +739,17 @@ def test_enhanced_logging_regex_parsing():
         parsing_pattern=r"Answer: (.*)",
     )
 
-    data = [{"raw_output": "Answer: test response"}]
+    data = [{"raw_output": {"content": "Answer: test response"}}]
     dataset = Dataset.from_list(data)
 
     with patch("sdg_hub.core.blocks.llm.text_parser_block.logger") as mock_logger:
         block.generate(dataset)
 
-        # Should log debug info about matches found
+        # Should log debug info about parsing
         mock_logger.debug.assert_called()
-        debug_call = mock_logger.debug.call_args[0][0]
-        assert "Regex parsing found" in debug_call
-        assert "matches with pattern" in debug_call
+        debug_calls = [call[0][0] for call in mock_logger.debug.call_args_list]
+        # Check for the general parsing message
+        assert any("Parsing outputs for" in call for call in debug_calls)
 
 
 def test_enhanced_logging_tag_parsing():
@@ -756,18 +762,17 @@ def test_enhanced_logging_tag_parsing():
         end_tags=["</answer>"],
     )
 
-    data = [{"raw_output": "<answer>test response</answer>"}]
+    data = [{"raw_output": {"content": "<answer>test response</answer>"}}]
     dataset = Dataset.from_list(data)
 
     with patch("sdg_hub.core.blocks.llm.text_parser_block.logger") as mock_logger:
         block.generate(dataset)
 
-        # Should log debug info about tag parsing
+        # Should log debug info about parsing
         mock_logger.debug.assert_called()
-        debug_call = mock_logger.debug.call_args[0][0]
-        assert "Tag parsing for" in debug_call
-        assert "found" in debug_call
-        assert "matches" in debug_call
+        debug_calls = [call[0][0] for call in mock_logger.debug.call_args_list]
+        # Check for the general parsing message
+        assert any("Parsing outputs for" in call for call in debug_calls)
 
 
 def test_generate_with_list_input_tag_parsing():
@@ -784,9 +789,9 @@ def test_generate_with_list_input_tag_parsing():
     data = [
         {
             "raw_output": [
-                "<answer>First response</answer>",
-                "<answer>Second response</answer>",
-                "<answer>Third response</answer>",
+                {"content": "<answer>First response</answer>"},
+                {"content": "<answer>Second response</answer>"},
+                {"content": "<answer>Third response</answer>"},
             ]
         }
     ]
@@ -814,8 +819,8 @@ def test_generate_with_list_input_regex_parsing():
     data = [
         {
             "raw_output": [
-                "Question: What is 2+2?\nAnswer: Four",
-                "Question: What is 3+3?\nAnswer: Six",
+                {"content": "Question: What is 2+2?\nAnswer: Four"},
+                {"content": "Question: What is 3+3?\nAnswer: Six"},
             ]
         }
     ]
@@ -843,8 +848,10 @@ def test_generate_with_list_input_multiple_matches_per_response():
     data = [
         {
             "raw_output": [
-                "<title>Title 1</title><content>Content 1</content><title>Title 2</title><content>Content 2</content>",
-                "<title>Title 3</title><content>Content 3</content>",
+                {
+                    "content": "<title>Title 1</title><content>Content 1</content><title>Title 2</title><content>Content 2</content>"
+                },
+                {"content": "<title>Title 3</title><content>Content 3</content>"},
             ]
         }
     ]
@@ -900,9 +907,9 @@ def test_generate_with_mixed_valid_invalid_list_items():
     data_with_empty = [
         {
             "raw_output": [
-                "<answer>Valid response 1</answer>",
-                "",  # Empty string
-                "<answer>Valid response 2</answer>",
+                {"content": "<answer>Valid response 1</answer>"},
+                {"content": ""},  # Empty string
+                {"content": "<answer>Valid response 2</answer>"},
             ]
         }
     ]
@@ -916,9 +923,11 @@ def test_generate_with_mixed_valid_invalid_list_items():
         assert result[0]["output"] == "Valid response 1"
         assert result[1]["output"] == "Valid response 2"
 
-        # Should log warning for empty string
+        # Should log warning for failed parsing (empty content)
         warning_calls = [call[0][0] for call in mock_logger.warning.call_args_list]
-        assert any("List item 1" in call and "empty" in call for call in warning_calls)
+        assert any(
+            "Failed to parse content from list item 1" in call for call in warning_calls
+        )
 
 
 def test_generate_with_list_input_parsing_failures():
@@ -935,10 +944,10 @@ def test_generate_with_list_input_parsing_failures():
     data = [
         {
             "raw_output": [
-                "<answer>Parseable response 1</answer>",
-                "No tags in this response",  # Won't parse
-                "<answer>Parseable response 2</answer>",
-                "Another response without tags",  # Won't parse
+                {"content": "<answer>Parseable response 1</answer>"},
+                {"content": "No tags in this response"},  # Won't parse
+                {"content": "<answer>Parseable response 2</answer>"},
+                {"content": "Another response without tags"},  # Won't parse
             ]
         }
     ]
@@ -972,7 +981,16 @@ def test_generate_with_list_input_all_invalid():
         end_tags=["</answer>"],
     )
 
-    data = [{"raw_output": ["No tags here", "", None, "Also no tags"]}]
+    data = [
+        {
+            "raw_output": [
+                {"content": "No tags here"},
+                {"content": ""},
+                None,
+                {"content": "Also no tags"},
+            ]
+        }
+    ]
     dataset = Dataset.from_list(data)
 
     result = block.generate(dataset)
@@ -982,7 +1000,7 @@ def test_generate_with_list_input_all_invalid():
 
 
 def test_backwards_compatibility_string_input():
-    """Test that string inputs still work exactly as before (backwards compatibility)."""
+    """Test that dict inputs work as expected."""
     block = TextParserBlock(
         block_name="test_block",
         input_cols="raw_output",
@@ -991,19 +1009,19 @@ def test_backwards_compatibility_string_input():
         end_tags=["</answer>"],
     )
 
-    # Traditional string input (existing behavior)
-    data = [{"raw_output": "<answer>Single string response</answer>"}]
+    # Dict input (new behavior)
+    data = [{"raw_output": {"content": "<answer>Single string response</answer>"}}]
     dataset = Dataset.from_list(data)
 
     result = block.generate(dataset)
 
-    # Should work exactly as before
+    # Should work as expected
     assert len(result) == 1
     assert result[0]["output"] == "Single string response"
 
 
 def test_generate_with_invalid_input_type():
-    """Test handling of completely invalid input types (not string or list)."""
+    """Test handling of completely invalid input types (not dict or list)."""
     block = TextParserBlock(
         block_name="test_block",
         input_cols="raw_output",
@@ -1012,18 +1030,18 @@ def test_generate_with_invalid_input_type():
         end_tags=["</answer>"],
     )
 
-    # Dictionary input (invalid type)
-    data = [{"raw_output": {"not": "valid"}}]
+    # Test with integer input (invalid type)
+    data = [{"raw_output": 123}]  # Integer instead of dict or list
     dataset = Dataset.from_list(data)
 
     with patch("sdg_hub.core.blocks.llm.text_parser_block.logger") as mock_logger:
         result = block.generate(dataset)
 
-        # Should log warning about invalid type
+        # Should log warning about invalid data type
         mock_logger.warning.assert_called()
-        warning_call = mock_logger.warning.call_args[0][0]
-        assert "invalid data type" in warning_call
-        assert "Expected str or List[str]" in warning_call
+        warning_calls = [call[0][0] for call in mock_logger.warning.call_args_list]
+        assert any("invalid data type" in call for call in warning_calls)
+        assert any("Expected str or List[str]" in call for call in warning_calls)
 
         # Should return empty result
         assert len(result) == 0
@@ -1045,8 +1063,8 @@ def test_expand_lists_false_basic_functionality():
     data = [
         {
             "raw_output": [
-                "<entity>A</entity><entity>B</entity>",
-                "<entity>C</entity>",
+                {"content": "<entity>A</entity><entity>B</entity>"},
+                {"content": "<entity>C</entity>"},
             ]
         }
     ]
@@ -1074,8 +1092,8 @@ def test_expand_lists_false_multiple_output_columns():
     data = [
         {
             "raw_output": [
-                "<title>Title 1</title><content>Content 1</content>",
-                "<title>Title 2</title><content>Content 2</content>",
+                {"content": "<title>Title 1</title><content>Content 1</content>"},
+                {"content": "<title>Title 2</title><content>Content 2</content>"},
             ]
         }
     ]
@@ -1103,8 +1121,8 @@ def test_expand_lists_false_with_regex_parsing():
     data = [
         {
             "raw_output": [
-                "Question 1\nAnswer: Response 1",
-                "Question 2\nAnswer: Response 2\nAnswer: Response 3",
+                {"content": "Question 1\nAnswer: Response 1"},
+                {"content": "Question 2\nAnswer: Response 2\nAnswer: Response 3"},
             ]
         }
     ]
@@ -1132,9 +1150,9 @@ def test_expand_lists_false_with_parsing_failures():
     data = [
         {
             "raw_output": [
-                "<entity>Valid 1</entity>",
-                "No tags here",  # Will fail to parse
-                "<entity>Valid 2</entity>",
+                {"content": "<entity>Valid 1</entity>"},
+                {"content": "No tags here"},  # Will fail to parse
+                {"content": "<entity>Valid 2</entity>"},
             ]
         }
     ]
@@ -1193,8 +1211,8 @@ def test_expand_lists_false_all_parsing_failures():
     data = [
         {
             "raw_output": [
-                "No tags here",
-                "Also no tags",
+                {"content": "No tags here"},
+                {"content": "Also no tags"},
             ]
         }
     ]
@@ -1221,8 +1239,8 @@ def test_expand_lists_true_backward_compatibility():
     data = [
         {
             "raw_output": [
-                "<entity>A</entity><entity>B</entity>",
-                "<entity>C</entity>",
+                {"content": "<entity>A</entity><entity>B</entity>"},
+                {"content": "<entity>C</entity>"},
             ]
         }
     ]
@@ -1255,8 +1273,8 @@ def test_expand_lists_default_value():
     data = [
         {
             "raw_output": [
-                "<entity>A</entity>",
-                "<entity>B</entity>",
+                {"content": "<entity>A</entity>"},
+                {"content": "<entity>B</entity>"},
             ]
         }
     ]

--- a/tests/blocks/llm/test_textparserblock.py
+++ b/tests/blocks/llm/test_textparserblock.py
@@ -1786,8 +1786,8 @@ def test_save_reasoning_content_multiple_responses_collected_as_list():
     # Should create single row with lists containing all responses and reasoning
     assert len(result) == 1
     assert result[0]["output"] == ["Response 1", "Response 2", "Response 3"]
-    # assert result[0]["test_block_reasoning_content"] == [
-    #     "Reasoning for response 1", 
-    #     "Reasoning for response 2", 
-    #     "Reasoning for response 3"
-    # ]
+    assert result[0]["test_block_reasoning_content"] == [
+        "Reasoning for response 1", 
+        "Reasoning for response 2", 
+        "Reasoning for response 3"
+    ]


### PR DESCRIPTION
This PR introduces the following two things - 

1. Retain the raw model response from `client_manager.py` for improved utility in further steps.
2. Option to save `reasoning_content` by setting `save_reasoning_content = True` for `TextParserBlock`, if reasoning is enabled for the `LLMChatBlock` or the whole flow. 

#### Usage

```yaml
  - block_type: TextParserBlock
    block_config:
      block_name: block_name
      input_cols: input_col
      output_cols: output_col
      start_tags: [""]
      end_tags: [""]
      save_reasoning_content: true
```

```python
flow.set_model_config(model="model-name",  enable_reasoning=True)
```

This will save the reasoning_content for the blocks where save_reasoning_content is set to true


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LLM responses now return structured dicts (content plus optional reasoning_content) across sync, async, and batch flows.
  * Text parser can save reasoning_content to outputs with configurable field name; new generate method to produce aggregated results; list-expansion includes reasoning content per row.
  * Output configuration now accepts dict-shaped results.

* **Documentation**
  * Examples and docstrings updated to show dict-based responses and reasoning_content usage.

* **Tests**
  * Tests and mocks updated to expect dict-shaped responses and cover reasoning_content behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->