### PR TITLE
Fix/supress litellm logs

### DIFF
--- a/src/sdg_hub/core/blocks/llm/client_manager.py
+++ b/src/sdg_hub/core/blocks/llm/client_manager.py
@@ -81,6 +81,12 @@ class LLMClientManager:
         """Configure LiteLLM settings."""
         # Set global timeout for LiteLLM
         litellm.request_timeout = self.config.timeout
+        
+        # Suppress litellm logs to reduce noise
+        import logging
+        logging.getLogger('litellm').setLevel(logging.WARNING)
+        logging.getLogger('litellm.proxy').setLevel(logging.WARNING)
+        logging.getLogger('litellm.router').setLevel(logging.WARNING)
 
         # Note: API keys are now passed directly in completion calls
         # instead of modifying environment variables for thread-safety

--- a/src/sdg_hub/core/blocks/llm/client_manager.py
+++ b/src/sdg_hub/core/blocks/llm/client_manager.py
@@ -81,12 +81,6 @@ class LLMClientManager:
         """Configure LiteLLM settings."""
         # Set global timeout for LiteLLM
         litellm.request_timeout = self.config.timeout
-        
-        # Suppress litellm logs to reduce noise
-        import logging
-        logging.getLogger('litellm').setLevel(logging.WARNING)
-        logging.getLogger('litellm.proxy').setLevel(logging.WARNING)
-        logging.getLogger('litellm.router').setLevel(logging.WARNING)
 
         # Note: API keys are now passed directly in completion calls
         # instead of modifying environment variables for thread-safety

--- a/src/sdg_hub/core/utils/logger_config.py
+++ b/src/sdg_hub/core/utils/logger_config.py
@@ -28,6 +28,12 @@ def setup_logger(name, log_dir=None, log_filename="sdg_hub.log"):
     log_level = os.getenv("LOG_LEVEL", "INFO").upper()
     logger = logging.getLogger(name)
     logger.setLevel(log_level)
+    
+    # Suppress litellm logs to reduce noise
+    litellm_log_level = os.getenv("LITELLM_LOG_LEVEL", "WARNING").upper()
+    logging.getLogger('litellm').setLevel(litellm_log_level)
+    logging.getLogger('litellm.proxy').setLevel(litellm_log_level)
+    logging.getLogger('litellm.router').setLevel(litellm_log_level)
 
     # Prevent duplicate handlers if setup_logger is called multiple times
     if not logger.handlers:

--- a/src/sdg_hub/core/utils/logger_config.py
+++ b/src/sdg_hub/core/utils/logger_config.py
@@ -28,12 +28,12 @@ def setup_logger(name, log_dir=None, log_filename="sdg_hub.log"):
     log_level = os.getenv("LOG_LEVEL", "INFO").upper()
     logger = logging.getLogger(name)
     logger.setLevel(log_level)
-    
+
     # Suppress litellm logs to reduce noise
     litellm_log_level = os.getenv("LITELLM_LOG_LEVEL", "WARNING").upper()
-    logging.getLogger('litellm').setLevel(litellm_log_level)
-    logging.getLogger('litellm.proxy').setLevel(litellm_log_level)
-    logging.getLogger('litellm.router').setLevel(litellm_log_level)
+    logging.getLogger("litellm").setLevel(litellm_log_level)
+    logging.getLogger("litellm.proxy").setLevel(litellm_log_level)
+    logging.getLogger("litellm.router").setLevel(litellm_log_level)
 
     # Prevent duplicate handlers if setup_logger is called multiple times
     if not logger.handlers:


### PR DESCRIPTION
This PR helps suppress LiteLLM logs to "Warning" level to reduce verbosity during generation.

Provides option to set litellm logging level through env variable `LITELLM_LOG_LEVEL`, default is "WARNING".

Addresses #380 

Files Changes - 
1. `src/sdg_hub/core/utils/logger_config.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced LITELLM_LOG_LEVEL environment variable to control verbosity of LLM-related logs (default: WARNING).
  * Applies consistently across core, proxy, and router logging, enabling easier debugging or quieter output without code changes.
  * No other logging behavior changed; existing log configuration remains intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->