### PR TITLE
Fix/support str text parser

### DIFF
--- a/src/sdg_hub/core/blocks/llm/text_parser_block.py
+++ b/src/sdg_hub/core/blocks/llm/text_parser_block.py
@@ -370,11 +370,14 @@ class TextParserBlock(BaseBlock):
                 return all_results
 
         # Handle dict inputs (existing logic)
-        elif isinstance(raw_output, dict):
+        elif isinstance(raw_output, dict) or isinstance(raw_output, str):
             if not raw_output:
                 logger.warning(f"Input column '{input_column}' contains empty dict")
                 return []
 
+            if isinstance(raw_output, str):
+                raw_output = {"content": raw_output}
+                
             parsed_outputs = self._handle_message(raw_output)
             if self.save_reasoning_content:
                 reasoning_content = parsed_outputs.pop(self.reasoning_content_field)

--- a/src/sdg_hub/core/blocks/llm/text_parser_block.py
+++ b/src/sdg_hub/core/blocks/llm/text_parser_block.py
@@ -377,7 +377,7 @@ class TextParserBlock(BaseBlock):
 
             if isinstance(raw_output, str):
                 raw_output = {"content": raw_output}
-                
+
             parsed_outputs = self._handle_message(raw_output)
             if self.save_reasoning_content:
                 reasoning_content = parsed_outputs.pop(self.reasoning_content_field)


### PR DESCRIPTION
This PR implements a fix to support `str` input for text parser block.

Features
1. TextParserBlock now works with `str` input as well, in case where two TextParserBlocks are chained together.
2. Supports previous functionality with dict and list[dict] as well.


Files changed

1. `src/sdg_hub/core/blocks/llm/text_parser_block.py` - fix
3. `tests/blocks/llm/test_textparserblock.py` - tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - TextParser now accepts raw string inputs in the input column, automatically wrapping them for parsing with start/end tags.
  - Empty string inputs are handled gracefully, yielding empty results with a warning.
- Tests
  - Added unit tests covering string input parsing and empty string behavior to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->