### PR TITLE
add paths-filter gh action to make labeled trigger alternate possible

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -21,15 +21,6 @@ on:
       - "main"
       - "release-**"
     types: [opened, synchronize, reopened, labeled]
-    paths:
-      # Only trigger on changes to relevant flows and examples (EXTEND THIS):
-      - 'src/sdg_hub/flows/qa_generation/document_grounded_qa/enhanced_multi_summary_qa/**'
-      - 'examples/knowledge_tuning/enhanced_summary_knowledge_tuning/**'
-      # Standard integration test triggers, DONT CHANGE THIS
-      - 'tests/integration/**/*.py'
-      - 'pyproject.toml'
-      - 'tox.ini'
-      - '.github/workflows/integration-test.yml'
 
 env:
   LC_ALL: en_US.UTF-8
@@ -42,19 +33,58 @@ permissions:
   contents: read
 
 jobs:
+  check-trigger:
+    name: "Check if integration tests should run"
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.check.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            relevant:
+              # Only trigger on changes to relevant flows and examples (EXTEND THIS):
+              - 'src/sdg_hub/flows/qa_generation/document_grounded_qa/enhanced_multi_summary_qa/**'
+              - 'examples/knowledge_tuning/enhanced_summary_knowledge_tuning/**'
+              # Standard integration test triggers, DONT CHANGE THIS
+              - 'tests/integration/**/*.py'
+              - 'pyproject.toml'
+              - 'tox.ini'
+              - '.github/workflows/integration-test.yml'
+
+      - name: Determine if tests should run
+        id: check
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || [[ "${{ github.event_name }}" == "push" ]]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            # Check if from fork
+            if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+              echo "should_run=false" >> $GITHUB_OUTPUT
+            # Check if labeled event with correct label
+            elif [[ "${{ github.event.action }}" == "labeled" ]] && [[ "${{ contains(github.event.pull_request.labels.*.name, 'run-integration-tests') }}" == "true" ]]; then
+              echo "should_run=true" >> $GITHUB_OUTPUT
+            # Check if relevant paths changed for non-labeled events
+            elif [[ "${{ github.event.action }}" != "labeled" ]] && [[ "${{ steps.filter.outputs.relevant }}" == "true" ]]; then
+              echo "should_run=true" >> $GITHUB_OUTPUT
+            else
+              echo "should_run=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "should_run=false" >> $GITHUB_OUTPUT
+          fi
+
   integration-test:
     name: "Integration Tests - ${{ matrix.python }} on ${{ matrix.platform }}"
     runs-on: "${{ matrix.platform }}"
+    needs: check-trigger
+    if: needs.check-trigger.outputs.should_run == 'true'
     # Require manual approval before running (via GitHub Environment)
     environment: integration-tests
-    # Skip fork PRs (they can't access environment secrets anyway)
-    # Also check for 'run-integration-tests' label on labeled events
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name == github.repository &&
-       (github.event.action != 'labeled' || contains(github.event.pull_request.labels.*.name, 'run-integration-tests')))
     strategy:
       matrix:
         python:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -60,22 +60,22 @@ jobs:
         id: check
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || [[ "${{ github.event_name }}" == "push" ]]; then
-            echo "should_run=true" >> $GITHUB_OUTPUT
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             # Check if from fork
             if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
-              echo "should_run=false" >> $GITHUB_OUTPUT
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
             # Check if labeled event with correct label
             elif [[ "${{ github.event.action }}" == "labeled" ]] && [[ "${{ contains(github.event.pull_request.labels.*.name, 'run-integration-tests') }}" == "true" ]]; then
-              echo "should_run=true" >> $GITHUB_OUTPUT
+              echo "should_run=true" >> "$GITHUB_OUTPUT"
             # Check if relevant paths changed for non-labeled events
             elif [[ "${{ github.event.action }}" != "labeled" ]] && [[ "${{ steps.filter.outputs.relevant }}" == "true" ]]; then
-              echo "should_run=true" >> $GITHUB_OUTPUT
+              echo "should_run=true" >> "$GITHUB_OUTPUT"
             else
-              echo "should_run=false" >> $GITHUB_OUTPUT
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
             fi
           else
-            echo "should_run=false" >> $GITHUB_OUTPUT
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
           fi
 
   integration-test:


### PR DESCRIPTION
## Add Label based integration-test trigger

- Add paths-filter based action to enable a smart conditional check of when to trigger-integration tests, based on https://github.com/dorny/paths-filter
- Now the workflow works as intended:

1.  Trigger if any of the specific paths are changed (change detected)
2. Trigger if label `run-integration-tests` is added (regardless of if the paths were changed or not)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined CI by adding a pre-check that determines when integration tests should run, improving reliability and reducing unnecessary executions.
  * Supports forked PRs, manual triggers, and labeled runs for greater control and consistency.

* **Tests**
  * Integration tests now run only when relevant changes or labels are present, accelerating feedback and conserving CI resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->