### PR TITLE
ci: add gitleaks secret scanning to pre-commit

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# Gitleaks configuration for SDG Hub
+#
+# Detects accidentally committed secrets (API keys, passwords, tokens).
+# Security patterns adapted from harness-eval-lab credential detection rules.
+#
+# Usage:
+#   pre-commit:  runs automatically on git commit
+#   manual:      gitleaks detect --config .gitleaks.toml
+
+title = "SDG Hub Secret Scanning"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "SDG Hub global allowlist"
+
+paths = [
+    '''\.gitleaks\.toml$''',
+    '''uv\.lock$''',
+]
+
+# Allow api_key as a parameter name in code (not actual key values)
+regexes = [
+    '''api_key\s*[:=]\s*["'](\.\.\.|\*+|<[^>]+>|None|null|""|\{\{[^}]+\}\}|your[_-]api[_-]key[_-]here)["']''',
+    '''["']api_key["']''',
+    '''\.api_key\b''',
+    '''api_key:\s*str''',
+]
+
+# Allow test fixtures and documentation examples
+[[allowlist.commits]]
+description = "test fixtures with fake keys"
+paths = [
+    '''tests/.*''',
+    '''docs/.*''',
+]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -2,7 +2,8 @@
 # Gitleaks configuration for SDG Hub
 #
 # Detects accidentally committed secrets (API keys, passwords, tokens).
-# Security patterns adapted from harness-eval-lab credential detection rules.
+# Regex allowlist tuned to suppress false positives on the ~70+ api_key
+# references in src/ (parameter names, type annotations, dict keys).
 #
 # Usage:
 #   pre-commit:  runs automatically on git commit
@@ -19,15 +20,23 @@ description = "SDG Hub global allowlist"
 paths = [
     '''\.gitleaks\.toml$''',
     '''uv\.lock$''',
+    # Test fixtures use dummy keys; docs use placeholder values.
+    # Trade-off: a real key pasted into a test file won't be caught here.
+    # CI-level scanning (follow-up) would cover this gap.
     '''tests/.*''',
     '''docs/.*''',
 ]
 
-# Allow api_key as a parameter name in code (not actual key values)
+# Match against the full source line, not just the extracted secret value.
+# This lets the regexes below distinguish code identifiers from real secrets.
 regexTarget = "line"
 regexes = [
-    '''api_key\s*[:=]\s*["'](\.\.\.|\*+|<[^>]+>|None|null|""|\{\{[^}]+\}\}|your[_-]api[_-]key[_-]here)["']''',
+    # Placeholder values: api_key="your-api-key", api_key="your_key_here", etc.
+    '''api_key\s*[:=]\s*["'](\.\.\.|\*+|<[^>]+>|None|null|""|\{\{[^}]+\}\}|your[._-](api[._-])?key([._-]here)?)["']''',
+    # Dict key access: config["api_key"], params['api_key']
     '''["']api_key["']''',
+    # Attribute access: self.api_key, model.api_key
     '''\.api_key\b''',
+    # Type annotations: api_key: str, api_key: Optional[str]
     '''api_key:\s*str''',
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -19,20 +19,15 @@ description = "SDG Hub global allowlist"
 paths = [
     '''\.gitleaks\.toml$''',
     '''uv\.lock$''',
+    '''tests/.*''',
+    '''docs/.*''',
 ]
 
 # Allow api_key as a parameter name in code (not actual key values)
+regexTarget = "line"
 regexes = [
     '''api_key\s*[:=]\s*["'](\.\.\.|\*+|<[^>]+>|None|null|""|\{\{[^}]+\}\}|your[_-]api[_-]key[_-]here)["']''',
     '''["']api_key["']''',
     '''\.api_key\b''',
     '''api_key:\s*str''',
-]
-
-# Allow test fixtures and documentation examples
-[[allowlist.commits]]
-description = "test fixtures with fake keys"
-paths = [
-    '''tests/.*''',
-    '''docs/.*''',
 ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,11 @@ repos:
         types: [python]
         pass_filenames: false
 
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.3
+    hooks:
+      - id: gitleaks
+
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v3.6.0
     hooks:


### PR DESCRIPTION
### Problem

SDG Hub handles API keys for multiple LLM providers (OpenAI, Anthropic, Azure, Bedrock, etc.) throughout the codebase. The existing `api_key_utils.py` with masking logic shows the team already cares about key safety, but there's currently no automated scanning to catch accidentally committed secrets. A single committed key in a test file, example, or config could leak credentials to the public repo.\n\n### What this PR adds

This PR introduces a pre-commit secret scanning layer using [gitleaks](https://github.com/gitleaks/gitleaks), an industry-standard tool for detecting hardcoded secrets in git repos.

**How it works:**
- `.gitleaks.toml` at the repo root configures the scanner. It extends gitleaks' default ruleset (which covers generic API keys, AWS keys, GitHub tokens, etc.) and adds SDG Hub-specific allowlists.
- The allowlists distinguish between `api_key` as a code identifier (parameter names, type annotations, dict keys) and actual key values. This prevents false positives on the ~50+ places SDG Hub legitimately references `api_key` in function signatures and Pydantic models.
- Test fixtures and documentation directories are allowlisted since they may contain example/placeholder keys.
- The hook runs in `.pre-commit-config.yaml` alongside the existing ruff, mypy, and conventional-commit hooks, so it integrates into the existing developer workflow with zero friction.

**What's included:**\n- `.gitleaks.toml` with custom rules and allowlists
- gitleaks hook added to `.pre-commit-config.yaml`

We noticed this gap while working on [harness-eval-lab](https://github.com/redhat-community-ai-tools/harness-eval-lab), where we develop evaluation and security tooling for AI agent setups. The allowlist design is informed by the credential detection patterns we built there."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Added pre-commit secret scanning using Gitleaks, enabling a default ruleset for automated detection before commits.
  * Introduced Gitleaks configuration to tailor scanning behavior and reduce false positives via an allowlist for known placeholder patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->