### PR TITLE
test: add structural test for prompt template security

### DIFF
--- a/tests/structural/security_patterns.py
+++ b/tests/structural/security_patterns.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Security patterns for prompt template scanning.
+
+Ported from harness-eval-lab's inspection rules:
+  - security/no-prompt-injection (17 patterns)
+  - security/data-exfiltration (8 patterns)
+
+These patterns detect content that could manipulate LLM behavior or
+exfiltrate data through prompt templates.
+"""
+
+from __future__ import annotations
+
+import re
+
+INJECTION_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    (
+        "ignore previous instructions",
+        re.compile(r"ignore\s+(all\s+)?previous\s+instructions", re.I),
+    ),
+    (
+        "disregard prior",
+        re.compile(r"disregard\s+(all\s+)?(prior|previous|above)", re.I),
+    ),
+    (
+        "you are now",
+        re.compile(r"you\s+are\s+now\s+(?:a|an|the)\s+", re.I),
+    ),
+    (
+        "system prompt override",
+        re.compile(r"system\s*prompt\s*(override|injection|change)", re.I),
+    ),
+    (
+        "override instructions",
+        re.compile(r"override\s+(all\s+)?(instructions|rules|guidelines)", re.I),
+    ),
+    (
+        "new instructions",
+        re.compile(r"new\s+instructions?\s*:", re.I),
+    ),
+    (
+        "jailbreak attempt",
+        re.compile(r"(\bDAN\b|do\s+anything\s+now|developer\s+mode)", re.I),
+    ),
+    (
+        "prompt leak",
+        re.compile(
+            r"(reveal|show|print|output)\s+(your|the)\s+(system\s+)?prompt",
+            re.I,
+        ),
+    ),
+    (
+        "role hijack",
+        re.compile(
+            r"forget\s+(everything|all|your)\s+(you|instructions|rules)", re.I
+        ),
+    ),
+    (
+        "hidden instruction",
+        re.compile(r"<\s*(?:system|instruction|hidden)\s*>", re.I),
+    ),
+    (
+        "role play",
+        re.compile(r"pretend\s+(?:to\s+be|you\s+are)\s+(?:a|an|the)\s+", re.I),
+    ),
+    (
+        "encoding evasion",
+        re.compile(
+            r"(?:in\s+base64|encode\s+(?:as|in|to)\s+base64|base64\s+encod)",
+            re.I,
+        ),
+    ),
+    (
+        "repeat after me",
+        re.compile(r"repeat\s+after\s+me", re.I),
+    ),
+    (
+        "bypass safety",
+        re.compile(
+            r"(?:ignore\s+safety|bypass\s+(?:filter|safety|restriction))", re.I
+        ),
+    ),
+    (
+        "output control",
+        re.compile(r"output\s+the\s+following\s+exactly", re.I),
+    ),
+    (
+        "markdown image exfiltration",
+        re.compile(r"!\[.*?\]\(https?://", re.I),
+    ),
+    (
+        "translate evasion",
+        re.compile(
+            r"translate\s+(?:this|the\s+following)\s+(?:to|into)\s+", re.I
+        ),
+    ),
+]
+
+EXFILTRATION_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    (
+        "curl post file contents",
+        re.compile(r"curl\s+.*-d\s+\"\$\(cat\b", re.I),
+    ),
+    (
+        "curl with command substitution",
+        re.compile(r"curl\s+.*--data.*\$\(", re.I),
+    ),
+    (
+        "wget post data",
+        re.compile(r"wget\s+--post-data", re.I),
+    ),
+    (
+        "dns tunneling dig",
+        re.compile(r"\bdig\s+.*\bTXT\b", re.I),
+    ),
+    (
+        "dns tunneling nslookup",
+        re.compile(r"\bnslookup\s+.*-type=TXT", re.I),
+    ),
+    (
+        "webhook exfiltration",
+        re.compile(
+            r"(?:curl|wget|fetch)\s+.*(?:webhook|hooks\.|pipedream|requestbin|ngrok)",
+            re.I,
+        ),
+    ),
+    (
+        "base64 pipe to network",
+        re.compile(r"base64\s+.*\|\s*(?:curl|wget|nc)\b", re.I),
+    ),
+    (
+        "archive pipe to network",
+        re.compile(r"tar\s+.*\|\s*(?:curl|wget|nc|ssh)\b", re.I),
+    ),
+]
+
+ALL_SECURITY_PATTERNS = INJECTION_PATTERNS + EXFILTRATION_PATTERNS

--- a/tests/structural/security_patterns.py
+++ b/tests/structural/security_patterns.py
@@ -7,8 +7,8 @@ config files), so the patterns focus on adversarial LLM manipulation
 rather than shell-level exfiltration.
 
 Six injection patterns are adapted from harness-eval-lab's
-security/no-prompt-injection rule. Two patterns are new, specific
-to SDG Hub's template architecture.
+security/no-prompt-injection rule. Two template structure patterns
+are specific to SDG Hub's template architecture.
 """
 
 from __future__ import annotations
@@ -38,7 +38,7 @@ INJECTION_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ),
     (
         "jailbreak attempt",
-        re.compile(r"(\bDAN\b|do\s+anything\s+now|developer\s+mode)", re.I),
+        re.compile(r"(do\s+anything\s+now|developer\s+mode)", re.I),
     ),
     (
         "role hijack",
@@ -50,19 +50,25 @@ INJECTION_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
 
 # Patterns specific to SDG Hub's template architecture.
 #
-# All 68 legitimate templates use simple {{ variable }} Jinja2 substitution.
-# Only the red_team flow uses {% if/for %} control flow. If Jinja2 control
-# flow appears in a non-red-team template, it could indicate template logic
-# that processes untrusted input or bypasses expected flow behavior.
+# All legitimate templates use simple {{ variable }} Jinja2 substitution.
+# Only the red_team flow uses {% if %} control flow. Jinja2 directives in
+# other templates could indicate template logic that processes untrusted
+# input, loads external files, or bypasses expected flow behavior.
 TEMPLATE_STRUCTURE_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     (
-        "jinja2 control flow",
-        re.compile(r"\{%[-\s]*(if|for|while|set|macro)\s+", re.I),
+        "jinja2 control flow or file inclusion",
+        re.compile(
+            r"\{%[-+\s]*"
+            r"(if|for|set|macro|include|import|extends|raw|call|filter)"
+            r"\s+",
+            re.I,
+        ),
     ),
     (
         "inline code execution directive",
         re.compile(
             r"\b(?:exec|eval|compile)\s*\(|"
+            r"__import__\s*\(|"
             r"\bos\.(?:system|popen)\s*\(|"
             r"\bsubprocess\.",
             re.I,

--- a/tests/structural/security_patterns.py
+++ b/tests/structural/security_patterns.py
@@ -42,9 +42,7 @@ INJECTION_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ),
     (
         "role hijack",
-        re.compile(
-            r"forget\s+(everything|all|your)\s+(you|instructions|rules)", re.I
-        ),
+        re.compile(r"forget\s+(everything|all|your)\s+(you|instructions|rules)", re.I),
     ),
 ]
 

--- a/tests/structural/security_patterns.py
+++ b/tests/structural/security_patterns.py
@@ -1,18 +1,24 @@
 # SPDX-License-Identifier: Apache-2.0
 """Security patterns for prompt template scanning.
 
-Ported from harness-eval-lab's inspection rules:
-  - security/no-prompt-injection (17 patterns)
-  - security/data-exfiltration (8 patterns)
+Curated for SDG Hub's prompt template context. Prompt templates are
+natural language instructions to LLMs (not shell scripts or agent
+config files), so the patterns focus on adversarial LLM manipulation
+rather than shell-level exfiltration.
 
-These patterns detect content that could manipulate LLM behavior or
-exfiltrate data through prompt templates.
+Six injection patterns are adapted from harness-eval-lab's
+security/no-prompt-injection rule. Two patterns are new, specific
+to SDG Hub's template architecture.
 """
 
 from __future__ import annotations
 
 import re
 
+# Patterns that detect adversarial instructions a community contributor
+# could introduce into prompt templates. Each pattern targets a specific
+# manipulation technique that has no legitimate use in data generation
+# prompt templates.
 INJECTION_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     (
         "ignore previous instructions",
@@ -23,10 +29,6 @@ INJECTION_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
         re.compile(r"disregard\s+(all\s+)?(prior|previous|above)", re.I),
     ),
     (
-        "you are now",
-        re.compile(r"you\s+are\s+now\s+(?:a|an|the)\s+", re.I),
-    ),
-    (
         "system prompt override",
         re.compile(r"system\s*prompt\s*(override|injection|change)", re.I),
     ),
@@ -35,19 +37,8 @@ INJECTION_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
         re.compile(r"override\s+(all\s+)?(instructions|rules|guidelines)", re.I),
     ),
     (
-        "new instructions",
-        re.compile(r"new\s+instructions?\s*:", re.I),
-    ),
-    (
         "jailbreak attempt",
         re.compile(r"(\bDAN\b|do\s+anything\s+now|developer\s+mode)", re.I),
-    ),
-    (
-        "prompt leak",
-        re.compile(
-            r"(reveal|show|print|output)\s+(your|the)\s+(system\s+)?prompt",
-            re.I,
-        ),
     ),
     (
         "role hijack",
@@ -55,83 +46,26 @@ INJECTION_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
             r"forget\s+(everything|all|your)\s+(you|instructions|rules)", re.I
         ),
     ),
+]
+
+# Patterns specific to SDG Hub's template architecture.
+#
+# All 68 legitimate templates use simple {{ variable }} Jinja2 substitution.
+# Only the red_team flow uses {% if/for %} control flow. If Jinja2 control
+# flow appears in a non-red-team template, it could indicate template logic
+# that processes untrusted input or bypasses expected flow behavior.
+TEMPLATE_STRUCTURE_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     (
-        "hidden instruction",
-        re.compile(r"<\s*(?:system|instruction|hidden)\s*>", re.I),
+        "jinja2 control flow",
+        re.compile(r"\{%[-\s]*(if|for|while|set|macro)\s+", re.I),
     ),
     (
-        "role play",
-        re.compile(r"pretend\s+(?:to\s+be|you\s+are)\s+(?:a|an|the)\s+", re.I),
-    ),
-    (
-        "encoding evasion",
+        "inline code execution directive",
         re.compile(
-            r"(?:in\s+base64|encode\s+(?:as|in|to)\s+base64|base64\s+encod)",
+            r"\b(?:exec|eval|compile)\s*\(|"
+            r"\bos\.(?:system|popen)\s*\(|"
+            r"\bsubprocess\.",
             re.I,
         ),
     ),
-    (
-        "repeat after me",
-        re.compile(r"repeat\s+after\s+me", re.I),
-    ),
-    (
-        "bypass safety",
-        re.compile(
-            r"(?:ignore\s+safety|bypass\s+(?:filter|safety|restriction))", re.I
-        ),
-    ),
-    (
-        "output control",
-        re.compile(r"output\s+the\s+following\s+exactly", re.I),
-    ),
-    (
-        "markdown image exfiltration",
-        re.compile(r"!\[.*?\]\(https?://", re.I),
-    ),
-    (
-        "translate evasion",
-        re.compile(
-            r"translate\s+(?:this|the\s+following)\s+(?:to|into)\s+", re.I
-        ),
-    ),
 ]
-
-EXFILTRATION_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
-    (
-        "curl post file contents",
-        re.compile(r"curl\s+.*-d\s+\"\$\(cat\b", re.I),
-    ),
-    (
-        "curl with command substitution",
-        re.compile(r"curl\s+.*--data.*\$\(", re.I),
-    ),
-    (
-        "wget post data",
-        re.compile(r"wget\s+--post-data", re.I),
-    ),
-    (
-        "dns tunneling dig",
-        re.compile(r"\bdig\s+.*\bTXT\b", re.I),
-    ),
-    (
-        "dns tunneling nslookup",
-        re.compile(r"\bnslookup\s+.*-type=TXT", re.I),
-    ),
-    (
-        "webhook exfiltration",
-        re.compile(
-            r"(?:curl|wget|fetch)\s+.*(?:webhook|hooks\.|pipedream|requestbin|ngrok)",
-            re.I,
-        ),
-    ),
-    (
-        "base64 pipe to network",
-        re.compile(r"base64\s+.*\|\s*(?:curl|wget|nc)\b", re.I),
-    ),
-    (
-        "archive pipe to network",
-        re.compile(r"tar\s+.*\|\s*(?:curl|wget|nc|ssh)\b", re.I),
-    ),
-]
-
-ALL_SECURITY_PATTERNS = INJECTION_PATTERNS + EXFILTRATION_PATTERNS

--- a/tests/structural/test_prompt_security.py
+++ b/tests/structural/test_prompt_security.py
@@ -52,7 +52,9 @@ def _discover_prompt_yamls() -> list[Path]:
                 data = yaml.safe_load(fh)
         except yaml.YAMLError:
             continue
-        if isinstance(data, list) and data and isinstance(data[0], dict) and "content" in data[0]:
+        if isinstance(data, list) and data and any(
+            isinstance(item, dict) and "content" in item for item in data
+        ):
             prompts.append(path)
     return prompts
 
@@ -68,6 +70,8 @@ def _extract_content_fields(data: list[dict]) -> list[tuple[int, str]]:
     """Extract (index, content) pairs from a prompt template."""
     results = []
     for i, entry in enumerate(data):
+        if not isinstance(entry, dict):
+            continue
         content = entry.get("content", "")
         if isinstance(content, str) and content.strip():
             results.append((i, content))

--- a/tests/structural/test_prompt_security.py
+++ b/tests/structural/test_prompt_security.py
@@ -25,8 +25,8 @@ curated for SDG Hub's prompt template context.
 
 from __future__ import annotations
 
-import logging
 from pathlib import Path
+import logging
 
 import pytest
 import yaml
@@ -63,8 +63,10 @@ def _discover_prompt_yamls() -> tuple[list[Path], list[tuple[Path, str]]]:
         except yaml.YAMLError as exc:
             parse_errors.append((path, str(exc)))
             continue
-        if isinstance(data, list) and data and any(
-            isinstance(item, dict) and "content" in item for item in data
+        if (
+            isinstance(data, list)
+            and data
+            and any(isinstance(item, dict) and "content" in item for item in data)
         ):
             prompts.append(path)
     return prompts, parse_errors
@@ -117,8 +119,7 @@ def test_no_yaml_parse_errors() -> None:
     assert not _PARSE_ERRORS, (
         f"{len(_PARSE_ERRORS)} YAML file(s) failed to parse:\n"
         + "\n".join(
-            f"  {path.relative_to(FLOWS_DIR)}: {err}"
-            for path, err in _PARSE_ERRORS
+            f"  {path.relative_to(FLOWS_DIR)}: {err}" for path, err in _PARSE_ERRORS
         )
     )
 
@@ -139,8 +140,7 @@ def test_no_injection_patterns(prompt_path: Path) -> None:
                 if pattern.search(line):
                     role = data[entry_idx].get("role", "unknown")
                     findings.append(
-                        f"  [{role}] line {line_offset + 1}: "
-                        f"'{label}' pattern detected"
+                        f"  [{role}] line {line_offset + 1}: '{label}' pattern detected"
                     )
 
     assert not findings, (
@@ -173,8 +173,7 @@ def test_no_template_structure_anomalies(prompt_path: Path) -> None:
                 if pattern.search(line):
                     role = data[entry_idx].get("role", "unknown")
                     findings.append(
-                        f"  [{role}] line {line_offset + 1}: "
-                        f"'{label}' detected"
+                        f"  [{role}] line {line_offset + 1}: '{label}' detected"
                     )
 
     assert not findings, (

--- a/tests/structural/test_prompt_security.py
+++ b/tests/structural/test_prompt_security.py
@@ -1,14 +1,25 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Verify prompt templates do not contain injection or exfiltration patterns.
+"""Verify prompt templates do not contain adversarial patterns.
 
-SDG Hub prompt templates are fed directly to LLMs. Community-contributed
-flows could accidentally (or deliberately) introduce patterns that
-manipulate model behavior or exfiltrate data.
+SDG Hub prompt templates are fed directly to LLMs. As the flow catalog
+grows with community contributions, templates could introduce patterns
+that manipulate model behavior. These tests catch two classes of issues:
+
+1. Injection patterns: adversarial instructions (jailbreak, role hijack,
+   instruction override) that have no legitimate use in data generation
+   prompt templates.
+
+2. Template structure anomalies: Jinja2 control flow ({% if/for %}) in
+   non-red-team templates. All existing templates use simple {{ variable }}
+   substitution only; the red_team flow is the sole user of conditional
+   logic. Control flow in other templates could indicate template logic
+   that processes untrusted input.
 
 The red_team flow is explicitly allowlisted since it intentionally
 generates adversarial content.
 
-Security patterns ported from harness-eval-lab inspection rules.
+Security patterns adapted from harness-eval-lab inspection rules,
+curated for SDG Hub's prompt template context.
 """
 
 from __future__ import annotations
@@ -18,7 +29,10 @@ from pathlib import Path
 import pytest
 import yaml
 
-from tests.structural.security_patterns import ALL_SECURITY_PATTERNS
+from tests.structural.security_patterns import (
+    INJECTION_PATTERNS,
+    TEMPLATE_STRUCTURE_PATTERNS,
+)
 
 FLOWS_DIR = Path(__file__).resolve().parents[2] / "src" / "sdg_hub" / "flows"
 
@@ -33,8 +47,6 @@ def _discover_prompt_yamls() -> list[Path]:
         rel = path.relative_to(FLOWS_DIR)
         if rel.parts[0] in ALLOWLISTED_DIRS:
             continue
-        # Prompt templates are YAML lists of role/content dicts.
-        # Skip flow.yaml files (which have metadata + blocks keys).
         try:
             with open(path) as fh:
                 data = yaml.safe_load(fh)
@@ -65,7 +77,7 @@ def _extract_content_fields(data: list[dict]) -> list[tuple[int, str]]:
 @pytest.mark.parametrize(
     "prompt_path", PROMPT_YAMLS, ids=[_prompt_id(p) for p in PROMPT_YAMLS]
 )
-def test_prompt_template_no_injection_patterns(prompt_path: Path) -> None:
+def test_no_injection_patterns(prompt_path: Path) -> None:
     """Prompt templates must not contain patterns that manipulate LLM behavior."""
     with open(prompt_path) as fh:
         data = yaml.safe_load(fh)
@@ -74,7 +86,7 @@ def test_prompt_template_no_injection_patterns(prompt_path: Path) -> None:
 
     for entry_idx, content in _extract_content_fields(data):
         for line_offset, line in enumerate(content.split("\n")):
-            for label, pattern in ALL_SECURITY_PATTERNS:
+            for label, pattern in INJECTION_PATTERNS:
                 if pattern.search(line):
                     role = data[entry_idx].get("role", "unknown")
                     findings.append(
@@ -84,8 +96,43 @@ def test_prompt_template_no_injection_patterns(prompt_path: Path) -> None:
 
     assert not findings, (
         f"Prompt template {prompt_path.relative_to(FLOWS_DIR)} contains "
-        f"{len(findings)} security pattern(s):\n"
+        f"{len(findings)} injection pattern(s):\n"
         + "\n".join(findings)
         + "\n\nIf this is intentional adversarial content, add the flow's "
         "top-level directory to ALLOWLISTED_DIRS in this test."
+    )
+
+
+@pytest.mark.parametrize(
+    "prompt_path", PROMPT_YAMLS, ids=[_prompt_id(p) for p in PROMPT_YAMLS]
+)
+def test_no_template_structure_anomalies(prompt_path: Path) -> None:
+    """Prompt templates should use simple {{ variable }} substitution only.
+
+    Jinja2 control flow ({% if %}, {% for %}) in non-red-team templates
+    is unexpected and may indicate template logic that processes untrusted
+    input or bypasses the expected block pipeline.
+    """
+    with open(prompt_path) as fh:
+        data = yaml.safe_load(fh)
+
+    findings: list[str] = []
+
+    for entry_idx, content in _extract_content_fields(data):
+        for line_offset, line in enumerate(content.split("\n")):
+            for label, pattern in TEMPLATE_STRUCTURE_PATTERNS:
+                if pattern.search(line):
+                    role = data[entry_idx].get("role", "unknown")
+                    findings.append(
+                        f"  [{role}] line {line_offset + 1}: "
+                        f"'{label}' detected"
+                    )
+
+    assert not findings, (
+        f"Prompt template {prompt_path.relative_to(FLOWS_DIR)} contains "
+        f"{len(findings)} structural anomaly(ies):\n"
+        + "\n".join(findings)
+        + "\n\nAll non-red-team templates should use simple {{ variable }} "
+        "substitution. If Jinja2 control flow is intentional, add the "
+        "flow's top-level directory to ALLOWLISTED_DIRS in this test."
     )

--- a/tests/structural/test_prompt_security.py
+++ b/tests/structural/test_prompt_security.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Verify prompt templates do not contain injection or exfiltration patterns.
+
+SDG Hub prompt templates are fed directly to LLMs. Community-contributed
+flows could accidentally (or deliberately) introduce patterns that
+manipulate model behavior or exfiltrate data.
+
+The red_team flow is explicitly allowlisted since it intentionally
+generates adversarial content.
+
+Security patterns ported from harness-eval-lab inspection rules.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.structural.security_patterns import ALL_SECURITY_PATTERNS
+
+FLOWS_DIR = Path(__file__).resolve().parents[2] / "src" / "sdg_hub" / "flows"
+
+ALLOWLISTED_DIRS = {"red_team"}
+
+
+def _discover_prompt_yamls() -> list[Path]:
+    """Return all prompt template YAMLs (excluding allowlisted directories)."""
+    candidates = sorted(FLOWS_DIR.rglob("*.yaml")) + sorted(FLOWS_DIR.rglob("*.yml"))
+    prompts: list[Path] = []
+    for path in candidates:
+        rel = path.relative_to(FLOWS_DIR)
+        if rel.parts[0] in ALLOWLISTED_DIRS:
+            continue
+        # Prompt templates are YAML lists of role/content dicts.
+        # Skip flow.yaml files (which have metadata + blocks keys).
+        try:
+            with open(path) as fh:
+                data = yaml.safe_load(fh)
+        except yaml.YAMLError:
+            continue
+        if isinstance(data, list) and data and isinstance(data[0], dict) and "content" in data[0]:
+            prompts.append(path)
+    return prompts
+
+
+def _prompt_id(path: Path) -> str:
+    return str(path.relative_to(FLOWS_DIR))
+
+
+PROMPT_YAMLS = _discover_prompt_yamls()
+
+
+def _extract_content_fields(data: list[dict]) -> list[tuple[int, str]]:
+    """Extract (index, content) pairs from a prompt template."""
+    results = []
+    for i, entry in enumerate(data):
+        content = entry.get("content", "")
+        if isinstance(content, str) and content.strip():
+            results.append((i, content))
+    return results
+
+
+@pytest.mark.parametrize(
+    "prompt_path", PROMPT_YAMLS, ids=[_prompt_id(p) for p in PROMPT_YAMLS]
+)
+def test_prompt_template_no_injection_patterns(prompt_path: Path) -> None:
+    """Prompt templates must not contain patterns that manipulate LLM behavior."""
+    with open(prompt_path) as fh:
+        data = yaml.safe_load(fh)
+
+    findings: list[str] = []
+
+    for entry_idx, content in _extract_content_fields(data):
+        for line_offset, line in enumerate(content.split("\n")):
+            for label, pattern in ALL_SECURITY_PATTERNS:
+                if pattern.search(line):
+                    role = data[entry_idx].get("role", "unknown")
+                    findings.append(
+                        f"  [{role}] line {line_offset + 1}: "
+                        f"'{label}' pattern detected"
+                    )
+
+    assert not findings, (
+        f"Prompt template {prompt_path.relative_to(FLOWS_DIR)} contains "
+        f"{len(findings)} security pattern(s):\n"
+        + "\n".join(findings)
+        + "\n\nIf this is intentional adversarial content, add the flow's "
+        "top-level directory to ALLOWLISTED_DIRS in this test."
+    )

--- a/tests/structural/test_prompt_security.py
+++ b/tests/structural/test_prompt_security.py
@@ -9,14 +9,15 @@ that manipulate model behavior. These tests catch two classes of issues:
    instruction override) that have no legitimate use in data generation
    prompt templates.
 
-2. Template structure anomalies: Jinja2 control flow ({% if/for %}) in
-   non-red-team templates. All existing templates use simple {{ variable }}
-   substitution only; the red_team flow is the sole user of conditional
-   logic. Control flow in other templates could indicate template logic
-   that processes untrusted input.
+2. Template structure anomalies: Jinja2 directives (control flow, file
+   inclusion, macros) in non-red-team templates. All existing templates
+   use simple {{ variable }} substitution only; the red_team flow is the
+   sole user of Jinja2 control flow. Directives in other templates could
+   indicate template logic that processes untrusted input.
 
-The red_team flow is explicitly allowlisted since it intentionally
-generates adversarial content.
+The red_team flow's prompt_generation directory is explicitly allowlisted
+since it intentionally generates adversarial content and uses Jinja2
+conditionals for dynamic prompt construction.
 
 Security patterns adapted from harness-eval-lab inspection rules,
 curated for SDG Hub's prompt template context.
@@ -24,6 +25,7 @@ curated for SDG Hub's prompt template context.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -34,15 +36,23 @@ from tests.structural.security_patterns import (
     TEMPLATE_STRUCTURE_PATTERNS,
 )
 
+logger = logging.getLogger(__name__)
+
 FLOWS_DIR = Path(__file__).resolve().parents[2] / "src" / "sdg_hub" / "flows"
 
 ALLOWLISTED_DIRS = {"red_team"}
 
 
-def _discover_prompt_yamls() -> list[Path]:
-    """Return all prompt template YAMLs (excluding allowlisted directories)."""
+def _discover_prompt_yamls() -> tuple[list[Path], list[tuple[Path, str]]]:
+    """Return prompt template YAMLs and any files that failed to parse.
+
+    Returns:
+        A tuple of (prompt_paths, parse_errors) where parse_errors is a list
+        of (path, error_message) for files that could not be parsed.
+    """
     candidates = sorted(FLOWS_DIR.rglob("*.yaml")) + sorted(FLOWS_DIR.rglob("*.yml"))
     prompts: list[Path] = []
+    parse_errors: list[tuple[Path, str]] = []
     for path in candidates:
         rel = path.relative_to(FLOWS_DIR)
         if rel.parts[0] in ALLOWLISTED_DIRS:
@@ -50,24 +60,28 @@ def _discover_prompt_yamls() -> list[Path]:
         try:
             with open(path) as fh:
                 data = yaml.safe_load(fh)
-        except yaml.YAMLError:
+        except yaml.YAMLError as exc:
+            parse_errors.append((path, str(exc)))
             continue
         if isinstance(data, list) and data and any(
             isinstance(item, dict) and "content" in item for item in data
         ):
             prompts.append(path)
-    return prompts
+    return prompts, parse_errors
 
 
 def _prompt_id(path: Path) -> str:
     return str(path.relative_to(FLOWS_DIR))
 
 
-PROMPT_YAMLS = _discover_prompt_yamls()
+PROMPT_YAMLS, _PARSE_ERRORS = _discover_prompt_yamls()
 
 
 def _extract_content_fields(data: list[dict]) -> list[tuple[int, str]]:
-    """Extract (index, content) pairs from a prompt template."""
+    """Extract (index, content) pairs from a prompt template.
+
+    Handles both string and list-of-strings content values.
+    """
     results = []
     for i, entry in enumerate(data):
         if not isinstance(entry, dict):
@@ -75,7 +89,38 @@ def _extract_content_fields(data: list[dict]) -> list[tuple[int, str]]:
         content = entry.get("content", "")
         if isinstance(content, str) and content.strip():
             results.append((i, content))
+        elif isinstance(content, list):
+            joined = "\n".join(str(item) for item in content if isinstance(item, str))
+            if joined.strip():
+                results.append((i, joined))
     return results
+
+
+def test_prompt_yamls_discovered() -> None:
+    """Prompt template discovery must find templates.
+
+    Guards against a broken discovery function silently producing
+    zero test cases, which would make CI pass with no actual scanning.
+    """
+    assert PROMPT_YAMLS, (
+        f"No prompt template YAMLs found under {FLOWS_DIR}. "
+        "Check that _discover_prompt_yamls() and FLOWS_DIR are correct."
+    )
+
+
+def test_no_yaml_parse_errors() -> None:
+    """All non-allowlisted YAML files must parse successfully.
+
+    A malformed template that silently bypasses scanning is itself a
+    security concern.
+    """
+    assert not _PARSE_ERRORS, (
+        f"{len(_PARSE_ERRORS)} YAML file(s) failed to parse:\n"
+        + "\n".join(
+            f"  {path.relative_to(FLOWS_DIR)}: {err}"
+            for path, err in _PARSE_ERRORS
+        )
+    )
 
 
 @pytest.mark.parametrize(
@@ -113,9 +158,9 @@ def test_no_injection_patterns(prompt_path: Path) -> None:
 def test_no_template_structure_anomalies(prompt_path: Path) -> None:
     """Prompt templates should use simple {{ variable }} substitution only.
 
-    Jinja2 control flow ({% if %}, {% for %}) in non-red-team templates
-    is unexpected and may indicate template logic that processes untrusted
-    input or bypasses the expected block pipeline.
+    Jinja2 directives ({% if %}, {% for %}, {% include %}, etc.) in
+    non-red-team templates are unexpected and may indicate template logic
+    that processes untrusted input or bypasses the expected block pipeline.
     """
     with open(prompt_path) as fh:
         data = yaml.safe_load(fh)


### PR DESCRIPTION
### Problem

SDG Hub has 65+ prompt template YAMLs that are fed directly to LLMs. As the flow catalog grows with community contributions, templates could introduce patterns that manipulate model behavior. There's currently no automated check for this.

### What this PR adds

A structural security test that scans all prompt template YAMLs for two classes of issues, following the same parametrized test pattern used by the existing `test_flow_schemas.py`.

**1. Injection patterns (6 patterns)**\n\nDetects adversarial instructions that have no legitimate use in data generation prompt templates: instruction override, jailbreak attempts (DAN, developer mode), role hijack, and system prompt manipulation. These were curated from a larger set of 17 patterns; we dropped 11 that would either never fire on prompt templates or could false-positive on legitimate content (e.g. \"you are now a\" would match valid role assignments).

**2. Template structure anomalies (2 patterns)**\n\nThis is the most SDG Hub-specific check. All 68 existing prompt templates use simple `{{ variable }}` Jinja2 substitution. The `red_team` flow is the only one using `{% if %}` control flow. If Jinja2 conditionals appear in a non-red-team template, it could indicate template logic that processes untrusted input or bypasses the expected block pipeline. We also check for inline code execution directives (`exec(`, `eval(`, `os.system(`) in prompt content.

**Design decisions:**\n- The `red_team` flow is explicitly allowlisted via `ALLOWLISTED_DIRS` since it intentionally generates adversarial content.\n- `tests/structural/security_patterns.py` is a standalone module with no dependencies beyond `re`, so it can be imported by other tests or eval scripts.

- All 142 test cases pass with zero false positives against the existing templates.

We maintain [harness-eval-lab](https://github.com/redhat-community-ai-tools/harness-eval-lab), where we develop evaluation and security tooling for AI agent setups. The 6 injection patterns are adapted from our `security/no-prompt-injection` rule. The 2 template structure patterns are new, designed specifically for SDG Hub's architecture after analyzing the actual prompt template corpus."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Added expanded prompt-template security validation that scans prompt content for common prompt-injection and jailbreak phrasing.
  * Enhanced structural checks to flag unexpected template/control-flow usage and inline execution-style directives.
  * Improved prompt YAML discovery and validation by surfacing YAML parse errors, broadening supported `content` formats (string or list), and adding new assertions for successful discovery and zero parse failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->