### PR TITLE
ci: add harness-eval static analysis for agent configurations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,7 +81,7 @@ jobs:
           persist-credentials: false
 
       - name: Install harness-eval
-        run: pip install -q "harness-eval==7.9.1"
+        run: pip install -q "harness-eval==7.9.2"
 
       - name: Run harness-eval lint
         run: harness-eval harness-lint . --preset recommended --fail-on-error --baseline .harness-eval-baseline.json

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,7 +81,7 @@ jobs:
           persist-credentials: false
 
       - name: Install harness-eval
-        run: pip install -q "harness-eval==7.9.0"
+        run: pip install -q "harness-eval==7.9.1"
 
       - name: Run harness-eval lint
         run: harness-eval harness-lint . --preset recommended --fail-on-error --baseline .harness-eval-baseline.json

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,9 @@ on:
       - '**.py'
       - 'pyproject.toml'
       - '.github/workflows/lint.yml'
+      - '.claude/**'
+      - '.claude-plugin/**'
+      - '.harness-eval-baseline.json'
   pull_request:
     branches:
       - "main"
@@ -17,6 +20,9 @@ on:
       - '**.py'
       - 'pyproject.toml'
       - '.github/workflows/lint.yml'
+      - '.claude/**'
+      - '.claude-plugin/**'
+      - '.harness-eval-baseline.json'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -62,3 +68,20 @@ jobs:
 
       - name: Run mypy type checker
         run: uv run mypy src/sdg_hub --show-error-codes
+
+  harness-eval:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install harness-eval
+        run: pip install -q "harness-eval==7.9.0"
+
+      - name: Run harness-eval lint
+        run: harness-eval harness-lint . --preset recommended --fail-on-error --baseline .harness-eval-baseline.json

--- a/.harness-eval-baseline.json
+++ b/.harness-eval-baseline.json
@@ -1,0 +1,120 @@
+{
+  "version": "1.0",
+  "findings": [
+    {
+      "rule_id": "content/orphan-skills",
+      "file": ".claude/skills/data-generation/SKILL.md",
+      "message_hash": "26cce1b86e6f6686"
+    },
+    {
+      "rule_id": "content/orphan-skills",
+      "file": ".claude/skills/flow-browser/SKILL.md",
+      "message_hash": "ea2e816a99a3f448"
+    },
+    {
+      "rule_id": "content/orphan-skills",
+      "file": ".claude/skills/setup-guide/SKILL.md",
+      "message_hash": "0104eefa300eca9e"
+    },
+    {
+      "rule_id": "content/orphan-skills",
+      "file": ".claude/skills/synthetic-data-generation/SKILL.md",
+      "message_hash": "d4850fb01fc3676e"
+    },
+    {
+      "rule_id": "content/allowed-tools-auto-approve",
+      "file": ".claude/skills/data-generation/SKILL.md",
+      "message_hash": "0e7823ff81a5565c"
+    },
+    {
+      "rule_id": "content/allowed-tools-auto-approve",
+      "file": ".claude/skills/data-generation/SKILL.md",
+      "message_hash": "c2c2b7f8fc38bb3f"
+    },
+    {
+      "rule_id": "content/allowed-tools-auto-approve",
+      "file": ".claude/skills/data-generation/SKILL.md",
+      "message_hash": "35fa0b9a72b98d68"
+    },
+    {
+      "rule_id": "quality/unfinished-content",
+      "file": ".claude/skills/flow-browser/SKILL.md",
+      "message_hash": "8a9f55714d899adb"
+    },
+    {
+      "rule_id": "content/allowed-tools-auto-approve",
+      "file": ".claude/skills/flow-browser/SKILL.md",
+      "message_hash": "35fa0b9a72b98d68"
+    },
+    {
+      "rule_id": "content/allowed-tools-auto-approve",
+      "file": ".claude/skills/flow-browser/SKILL.md",
+      "message_hash": "c2c2b7f8fc38bb3f"
+    },
+    {
+      "rule_id": "content/broken-references",
+      "file": ".claude/skills/setup-guide/SKILL.md",
+      "message_hash": "6a8cc3154f375424"
+    },
+    {
+      "rule_id": "quality/imprecise-instruction",
+      "file": ".claude/skills/setup-guide/SKILL.md",
+      "message_hash": "6080bf04ba04737c"
+    },
+    {
+      "rule_id": "content/allowed-tools-auto-approve",
+      "file": ".claude/skills/setup-guide/SKILL.md",
+      "message_hash": "c2c2b7f8fc38bb3f"
+    },
+    {
+      "rule_id": "content/allowed-tools-auto-approve",
+      "file": ".claude/skills/setup-guide/SKILL.md",
+      "message_hash": "35fa0b9a72b98d68"
+    },
+    {
+      "rule_id": "quality/unfinished-content",
+      "file": ".claude/skills/synthetic-data-generation/SKILL.md",
+      "message_hash": "297eb7de387f6a3d"
+    },
+    {
+      "rule_id": "quality/unfinished-content",
+      "file": ".claude/skills/synthetic-data-generation/SKILL.md",
+      "message_hash": "b8df52889e9b24c7"
+    },
+    {
+      "rule_id": "security/unbounded-delegation",
+      "file": ".claude/skills/synthetic-data-generation/SKILL.md",
+      "message_hash": "af2dae57b761cdd8"
+    },
+    {
+      "rule_id": "content/description-length",
+      "file": ".claude/skills/synthetic-data-generation/SKILL.md",
+      "message_hash": "cb837b5e517f7a75"
+    },
+    {
+      "rule_id": "hooks/pre-trust-permissions",
+      "file": ".claude/settings.json",
+      "message_hash": "b5c869f9c37a57d0"
+    },
+    {
+      "rule_id": "hooks/no-commit-guard",
+      "file": ".claude/settings.json",
+      "message_hash": "5f33e2faf5a29b19"
+    },
+    {
+      "rule_id": "hooks/no-audit-trail",
+      "file": ".claude/settings.json",
+      "message_hash": "bde50376928a9cd9"
+    },
+    {
+      "rule_id": "security/no-credential-access",
+      "file": ".github/actions/free-disk-space/action.yml",
+      "message_hash": "ccc5483f1ed61f05"
+    },
+    {
+      "rule_id": "security/no-credential-access",
+      "file": ".github/actions/free-disk-space/action.yml",
+      "message_hash": "f27b25b0e1f2f8ce"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add an advisory CI job that runs `harness-eval harness-lint` against the
  repo's agent configuration (skills, CLAUDE.md, hooks, plugin config)
- Uses the `recommended` preset (97 deterministic rules) pinned to `harness-eval==7.9.0`
- Includes a baseline file to suppress pre-existing findings for incremental
  adoption. New findings introduced in future PRs will be caught.

## About harness-eval

[harness-eval](https://github.com/redhat-community-ai-tools/harness-eval) is a
deterministic linter for AI code agent setups. It auto-detects agent tooling
(Claude Code, Cursor, Windsurf, Cline, Copilot, Gemini CLI, OpenCode), builds a
component graph, and runs 97 rules to catch issues like credential exfiltration,
prompt injection, broken references, and skill/hook conflicts.

Available as: CLI (`pip install harness-eval`), Claude Code plugin, GitHub
Action, Tekton Task, and Cursor commands. This PR integrates the CI version for
sdg_hub's GitHub Actions pipeline.

## Test plan

- [ ] CI job runs successfully on this PR
- [ ] Verify findings are relevant (baseline any confirmed false positives)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated quality checks for configuration and workflow changes.
  * Added baseline tracking for 19 known repository evaluation findings.
  * Quality checks now run for relevant changes submitted to or targeting the main branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->